### PR TITLE
Issue #4 - Mutants! Btrieve

### DIFF
--- a/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
+++ b/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
@@ -478,8 +478,8 @@ namespace MBBSEmu.Btrieve
                 EnumBtrieveOperationCodes.GetKeyFirst when currentQuery.KeyDataType == EnumKeyDataType.Zstring => GetByKeyFirstAlphabetical(currentQuery),
                 EnumBtrieveOperationCodes.GetFirst => GetByKeyFirstNumeric(currentQuery),
                 EnumBtrieveOperationCodes.GetKeyFirst => GetByKeyFirstNumeric(currentQuery),
-                EnumBtrieveOperationCodes.GetKeyNext when currentQuery.KeyDataType == EnumKeyDataType.AutoInc => GetByKeyNextAutoInc(currentQuery),
-                EnumBtrieveOperationCodes.GetKeyNext => GetByKeyNext(currentQuery),
+                EnumBtrieveOperationCodes.GetKeyNext when currentQuery.KeyDataType == EnumKeyDataType.Zstring => GetByKeyNext(currentQuery),
+                EnumBtrieveOperationCodes.GetKeyNext => GetByKeyNextNumeric(currentQuery),
                 EnumBtrieveOperationCodes.GetKeyGreater when currentQuery.KeyDataType == EnumKeyDataType.Zstring => GetByKeyGreaterAlphabetical(currentQuery),
                 EnumBtrieveOperationCodes.GetGreater when currentQuery.KeyDataType == EnumKeyDataType.Zstring => GetByKeyGreaterAlphabetical(currentQuery),
                 EnumBtrieveOperationCodes.GetGreater => GetByKeyGreaterNumeric(currentQuery),
@@ -620,7 +620,7 @@ namespace MBBSEmu.Btrieve
         }
 
         /// <summary>
-        ///     GetNext for Non-AutoInc Key Types
+        ///     GetNext for Non-Numeric Key Types
         ///
         ///     Search for the next logical record with a matching Key that comes after the current Position
         /// </summary>
@@ -637,7 +637,7 @@ namespace MBBSEmu.Btrieve
 
                 if (recordKey.SequenceEqual(query.Key))
                 {
-                    Position = (uint)r.Offset;
+                    Position = r.Offset;
                     return 1;
                 }
             }
@@ -647,13 +647,13 @@ namespace MBBSEmu.Btrieve
         }
 
         /// <summary>
-        ///     GetNext for AutoInc key types
+        ///     GetNext for Numeric key types
         ///
         ///     Key Value needs to be incremented, then the specific key needs to be found
         /// </summary>
         /// <param name="query"></param>
         /// <returns></returns>
-        private ushort GetByKeyNextAutoInc(BtrieveQuery query)
+        private ushort GetByKeyNextNumeric(BtrieveQuery query)
         {
             //Set Query Value to Current Value
             query.Key = (new ReadOnlySpan<byte>(GetRecord()).Slice(query.KeyOffset, query.KeyLength)).ToArray();


### PR DESCRIPTION
This fixes the issues of Monsters and some Items not loading in Mutants!

### Issue
Creature names showing up blank

### Cause

During INIT, Mutants! loads the Monsters Btrieve file (MJWMUTM.DAT/EMU) by performing a `GetKeyFirst()` on Key 0 (`integer`, `monsterId` I assume) setting the current record to the first Monster (id == 0). It then performs a `GetKeyNext()` on Key 0 until Btrieve returns a 0, meaning there are no more records.

Below is the log pre-fix:

```
2020-08-13 14:06:39.0316 Info MBBSEmu.HostProcess.ExportedModules.Majorbbs.alczer Allocated 49270 bytes starting at 0113:0000
2020-08-13 14:10:15.9529 Info MBBSEmu.HostProcess.ExportedModules.Majorbbs.setmem Set 49270 bytes to 00 starting at 0113:0000
2020-08-13 14:13:09.3671 Info MBBSEmu.HostProcess.ExportedModules.Majorbbs.qrybtv Performed Query 55 on MJWMUTM.EMU (0100:C674) with result 1
2020-08-13 14:15:05.1726 Info MBBSEmu.HostProcess.ExportedModules.Majorbbs.gabbtv Performed Btrieve Step - Btrieve Record Updated 0100:C749, 130 bytes written to 0113:0000
2020-08-13 14:19:34.8424 Info MBBSEmu.HostProcess.ExportedModules.Majorbbs.qnpbtv Performed Query GetKeyNext on MJWMUTM.EMU (0100:C674) with result 0
```

You can see it allocates memory for the records it's reading (130 bytes * (378 records + 1)), performs a `GetKeyFirst()` (`55`), gets the record then does a `GetKeyNext()` which returns zero. This means only one Monster record was being loaded into memory and when it would set an offset in that range to load a monster, the entire record was zeroed out.

### Fix

I modified the logic in BtrieveFileProcessor.cs to handle _any_ numeric value as an auto-incrementing value when performing a `GetKeyNext()`. This increments the key value it queries for until it can no longer find a value if the key is now past the limit of the values in the file.

Additionally - I modified the previous logic to be used only for Zstring file types, where if a `GetKeyNext()` is called on a string key, it will search for the next duplicate key. I think only one module has done this to date.

---

### Issue
When performing Btrieve Queries, the BTVFILE->data record wasn't being updated with the current record.

### Cause
When performing Btrieve Queries, the Position (absolute) is updated within the Btrieve File Processor, so when a subsequent `GetRecord()` call is made, the record at the current Position is loaded into the specified record pointer. 

For queries such as `qnpbtv()` and `qrybtv()` where an explicit record pointer isn't passed in, the record at the BTVFILE->data pointer wasn't being updated if the query was successful.

### Fix

On successful queries (result == 1) in `qnpbtv()` and `qrybtv()`, update the BTVFILE->data pointer with the current record.

![image](https://user-images.githubusercontent.com/1139047/90181971-3e0f5a00-dd7f-11ea-89ce-4e702b0f74b8.png)
