### PR TITLE
Change most of the socket code to async

### DIFF
--- a/MBBSEmu/IO/FileUtility.cs
+++ b/MBBSEmu/IO/FileUtility.cs
@@ -1,4 +1,7 @@
+<<<<<<< HEAD
 ﻿using System;
+=======
+>>>>>>> 499a85239cb33880ca4801eff2a2bf1e9aeb2a76
 using NLog;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -96,5 +99,15 @@ namespace MBBSEmu.IO
         public string CorrectPathSeparator(string fileName) => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? fileName
             : fileName.Replace(@"\", "/");
+<<<<<<< HEAD
+=======
+
+
+        /// <summary>
+        ///     String containing the executing path of MBBSEmu
+        /// </summary>
+        /// <returns></returns>
+        public static string ExecutingPath => $"{Directory.GetCurrentDirectory()}{Path.DirectorySeparatorChar}";
+>>>>>>> 499a85239cb33880ca4801eff2a2bf1e9aeb2a76
     }
 }

--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -1,4 +1,4 @@
-﻿using MBBSEmu.Database.Repositories.Account;
+using MBBSEmu.Database.Repositories.Account;
 using MBBSEmu.Database.Repositories.AccountKey;
 using MBBSEmu.DependencyInjection;
 using MBBSEmu.HostProcess;
@@ -104,9 +104,9 @@ namespace MBBSEmu
                 if (!File.Exists($"BBSGEN.DAT"))
                 {
                     _logger.Warn($"Unable to find MajorBBS/WG Generic User Database, creating new copy of BBSGEN.VIR to BBSGEN.DAT");
-                   
+
                     var resourceManager = ServiceResolver.GetService<IResourceManager>();
-                    
+
                     File.WriteAllBytes($"BBSGEN.DAT", resourceManager.GetResource("MBBSEmu.Assets.BBSGEN.VIR").ToArray());
                 }
 
@@ -177,7 +177,7 @@ namespace MBBSEmu
                     }
 
                     ServiceResolver.GetService<ISocketServer>()
-                        .Start(EnumSessionType.Telent, int.Parse(config["Telnet.Port"]));
+                        .Start(EnumSessionType.Telnet, int.Parse(config["Telnet.Port"]));
 
                     _logger.Info($"Telnet listening on port {config["Telnet.Port"]}");
                 }

--- a/MBBSEmu/Session/EnumSessionType.cs
+++ b/MBBSEmu/Session/EnumSessionType.cs
@@ -1,8 +1,8 @@
-﻿namespace MBBSEmu.Session
+namespace MBBSEmu.Session
 {
     public enum EnumSessionType
     {
-        Telent,
+        Telnet,
         Rlogin
     }
 }


### PR DESCRIPTION
Socket accepting is now fully async. TelnetSession has async receiving implemented, but there's still the Sender thread that seems to only be used for the invoke echo stuff? We might want to try to revisit removing that. Would be nice to have no threads in TelnetSession at all. 

Improved the error handling.

RLogin hasn't been updated yet as I figured I'd get Telnet working smoothly first, then port everything.