### PR TITLE
Implement a Ctrl-C handler and modify the server to exit cleanly.

### DIFF
--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -355,6 +355,7 @@ namespace MBBSEmu.HostProcess.HostRoutines
         {
             EchoToClient(session, "\r\n\r\n|GREEN||B|Ok, thanks for calling!\r\n\r\nHave a nice day...\r\n\r\n".EncodeToANSIArray());
             session.SessionState = EnumSessionState.LoggingOffProcessing;
+            session.Stop();
         }
 
         private void SignupUsernameDisplay(SessionBase session)

--- a/MBBSEmu/HostProcess/IMbbsHost.cs
+++ b/MBBSEmu/HostProcess/IMbbsHost.cs
@@ -1,20 +1,16 @@
-﻿using MBBSEmu.Module;
+using MBBSEmu.Module;
+using MBBSEmu.Server;
 using MBBSEmu.Session;
 using System.Collections.Generic;
 
 namespace MBBSEmu.HostProcess
 {
-    public interface IMbbsHost
+    public interface IMbbsHost : IStoppable
     {
         /// <summary>
         ///     Starts the MbbsHost Worker Thread
         /// </summary>
         void Start();
-
-        /// <summary>
-        ///     Stops the MbbsHost worker thread
-        /// </summary>
-        void Stop();
 
         /// <summary>
         ///     Adds a Module to the MbbsHost Process and sets it up for use

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -1,4 +1,4 @@
-﻿using MBBSEmu.CPU;
+using MBBSEmu.CPU;
 using MBBSEmu.Disassembler.Artifacts;
 using MBBSEmu.HostProcess.ExportedModules;
 using MBBSEmu.HostProcess.HostRoutines;
@@ -212,6 +212,37 @@ namespace MBBSEmu.HostProcess
                 ProcessTasks();
             }
 
+            Shutdown();
+        }
+
+        private void Shutdown()
+        {
+            _logger.Info("SHUTTING DOWN");
+
+            // kill all active sessions
+            foreach (SessionBase session in _channelDictionary.Values) {
+                session.Stop();
+            }
+
+            // let modules clean themselves up
+            callModuleRoutine("finrou");
+        }
+
+        private void callModuleRoutine(string routine, ushort channel = ushort.MaxValue) {
+            foreach (var m in _modules.Values)
+            {
+                if (!m.EntryPoints.TryGetValue(routine, out var routineEntryPoint)) continue;
+
+                if (routineEntryPoint.Segment != 0 &&
+                    routineEntryPoint.Offset != 0)
+                {
+#if DEBUG
+                    _logger.Info($"Calling {routine} on module {m.ModuleIdentifier} for channel {channel}");
+#endif
+
+                    Run(m.ModuleIdentifier, routineEntryPoint, ushort.MaxValue);
+                }
+            }
         }
 
         /// <summary>
@@ -237,7 +268,10 @@ namespace MBBSEmu.HostProcess
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessDisconnects()
         {
-            //Any Disconnects
+            // for removing channels sequentially, starting with the highest index to not break
+            // _channelDictionary
+            Stack<ushort> channelsToRemove = new Stack<ushort>();
+
             for (ushort i = 0; i < _channelDictionary.Count; i++)
             {
                 //Because users might not be on sequential channels (0,1,3), we verify if the channel number
@@ -247,8 +281,12 @@ namespace MBBSEmu.HostProcess
                 //We only process channels that are logged off
                 if (_channelDictionary[i].SessionState != EnumSessionState.LoggedOff) continue;
 
-                _logger.Info($"Removing LoggedOff Channel: {i}");
-                _channelDictionary.Remove(i);
+                channelsToRemove.Push(i);
+            }
+
+            while (channelsToRemove.Count > 0)
+            {
+                RemoveSession(channelsToRemove.Pop());
             }
         }
 
@@ -321,17 +359,7 @@ namespace MBBSEmu.HostProcess
 
             if (doLoginRoutine)
             {
-                foreach (var m in _modules.Values)
-                {
-                    //No Login Routine for the Module? NEXT!
-                    if (!m.EntryPoints.TryGetValue("lonrou", out var logonRoutineEntryPoint)) continue;
-
-                    if (logonRoutineEntryPoint.Segment != 0 &&
-                        logonRoutineEntryPoint.Offset != 0)
-                    {
-                        Run(m.ModuleIdentifier, logonRoutineEntryPoint, session.Channel);
-                    }
-                }
+                callModuleRoutine("lonrou", session.Channel);
             }
 
             session.SessionState = EnumSessionState.MainMenuDisplay;
@@ -444,7 +472,7 @@ namespace MBBSEmu.HostProcess
         ///     Invokes routine registered during MAJORBBS->RTKICK()
         ///
         ///     Methods registered using RTKICK are automatically invoked after a specified delay (in seconds). Methods
-        ///     only execute once and are then discarded. 
+        ///     only execute once and are then discarded.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ProcessRTKICK()
@@ -589,7 +617,21 @@ namespace MBBSEmu.HostProcess
         /// </summary>
         /// <param name="channel"></param>
         /// <returns></returns>
-        public bool RemoveSession(ushort channel) => _channelDictionary.Remove(channel);
+        public bool RemoveSession(ushort channel) {
+            if (!_channelDictionary.ContainsKey(channel))
+            {
+                return false;
+            }
+
+            _logger.Info($"Removing Channel: {channel}");
+
+            callModuleRoutine("huprou", channel);
+
+            _channelDictionary[channel].Stop();
+            _channelDictionary.Remove(channel);
+
+            return true;
+        }
 
         /// <summary>
         ///     Runs the specified routine in the specified module

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -225,10 +225,10 @@ namespace MBBSEmu.HostProcess
             }
 
             // let modules clean themselves up
-            callModuleRoutine("finrou");
+            CallModuleRoutine("finrou");
         }
 
-        private void callModuleRoutine(string routine, ushort channel = ushort.MaxValue) {
+        private void CallModuleRoutine(string routine, ushort channel = ushort.MaxValue) {
             foreach (var m in _modules.Values)
             {
                 if (!m.EntryPoints.TryGetValue(routine, out var routineEntryPoint)) continue;
@@ -240,7 +240,7 @@ namespace MBBSEmu.HostProcess
                     _logger.Info($"Calling {routine} on module {m.ModuleIdentifier} for channel {channel}");
 #endif
 
-                    Run(m.ModuleIdentifier, routineEntryPoint, ushort.MaxValue);
+                    Run(m.ModuleIdentifier, routineEntryPoint, channel);
                 }
             }
         }
@@ -359,7 +359,7 @@ namespace MBBSEmu.HostProcess
 
             if (doLoginRoutine)
             {
-                callModuleRoutine("lonrou", session.Channel);
+                CallModuleRoutine("lonrou", session.Channel);
             }
 
             session.SessionState = EnumSessionState.MainMenuDisplay;
@@ -625,7 +625,7 @@ namespace MBBSEmu.HostProcess
 
             _logger.Info($"Removing Channel: {channel}");
 
-            callModuleRoutine("huprou", channel);
+            CallModuleRoutine("huprou", channel);
 
             _channelDictionary[channel].Stop();
             _channelDictionary.Remove(channel);

--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -20,7 +20,7 @@ namespace MBBSEmu
     {
         public const string DefaultEmuSettingsFilename = "appsettings.json";
 
-        private static ILogger _logger;
+        private ILogger _logger;
 
         private string sInputModule = string.Empty;
         private string sInputPath = string.Empty;
@@ -279,10 +279,11 @@ namespace MBBSEmu
 
         private void cancelKeyPressHandler(object sender, ConsoleCancelEventArgs args)
         {
-            // so args.Cancel is a bit strange. Cancel means to cancel to the Ctrl-C processing, so
+            // so args.Cancel is a bit strange. Cancel means to cancel the Ctrl-C processing, so
             // setting it to true keeps the app alive. We want this at first to allow the shutdown
             // routines to process naturally. If we get a 2nd (or more) Ctrl-C, then we set
-            // args.Cancel to false which means the app will die a horrible death.
+            // args.Cancel to false which means the app will die a horrible death, and prevents the
+            // app from being unkillable by normal means.
             args.Cancel = cancellationRequests > 0 ? false : true;
 
             cancellationRequests++;

--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -5,6 +5,7 @@ using MBBSEmu.HostProcess;
 using MBBSEmu.Module;
 using MBBSEmu.Reports;
 using MBBSEmu.Resources;
+using MBBSEmu.Server;
 using MBBSEmu.Server.Socket;
 using MBBSEmu.Session;
 using Microsoft.Extensions.Configuration;
@@ -21,17 +22,23 @@ namespace MBBSEmu
 
         private static ILogger _logger;
 
-        private static string sInputModule = string.Empty;
-        private static string sInputPath = string.Empty;
-        private static bool bApiReport = false;
-        private static bool bConfigFile = false;
-        private static string sConfigFile = string.Empty;
-        private static string sSettingsFile;
-        private static bool bResetDatabase = false;
-        private static string sSysopPassword = string.Empty;
+        private string sInputModule = string.Empty;
+        private string sInputPath = string.Empty;
+        private bool bApiReport = false;
+        private bool bConfigFile = false;
+        private string sConfigFile = string.Empty;
+        private string sSettingsFile;
+        private bool bResetDatabase = false;
+        private string sSysopPassword = string.Empty;
+        private List<IStoppable> runningServices = new List<IStoppable>();
+        private int cancellationRequests = 0;
 
         static void Main(string[] args)
         {
+            new Program().Run(args);
+        }
+
+        private void Run(String[] args) {
             try
             {
                 if (args.Length == 0)
@@ -196,6 +203,8 @@ namespace MBBSEmu
 
                 host.Start();
 
+                runningServices.Add(host);
+
                 //Setup and Run Telnet Server
                 if (bool.TryParse(config["Telnet.Enabled"], out var telnetEnabled) && telnetEnabled)
                 {
@@ -205,10 +214,12 @@ namespace MBBSEmu
                         return;
                     }
 
-                    ServiceResolver.GetService<ISocketServer>()
-                        .Start(EnumSessionType.Telnet, int.Parse(config["Telnet.Port"]));
+                    ISocketServer telnetService = ServiceResolver.GetService<ISocketServer>();
+                    telnetService.Start(EnumSessionType.Telnet, int.Parse(config["Telnet.Port"]));
 
                     _logger.Info($"Telnet listening on port {config["Telnet.Port"]}");
+
+                    runningServices.Add(telnetService);
                 }
                 else
                 {
@@ -230,10 +241,12 @@ namespace MBBSEmu
                         return;
                     }
 
-                    ServiceResolver.GetService<ISocketServer>()
-                        .Start(EnumSessionType.Rlogin, int.Parse(config["Rlogin.Port"]));
+                    ISocketServer rloginService = ServiceResolver.GetService<ISocketServer>();
+                    rloginService.Start(EnumSessionType.Rlogin, int.Parse(config["Rlogin.Port"]));
 
                     _logger.Info($"Rlogin listening on port {config["Rlogin.Port"]}");
+
+                    runningServices.Add(rloginService);
 
                     if (bool.Parse(config["Rlogin.PortPerModule"]))
                     {
@@ -241,8 +254,9 @@ namespace MBBSEmu
                         foreach (var m in modules)
                         {
                             _logger.Info($"Rlogin {m.ModuleIdentifier} listening on port {rloginPort}");
-                            ServiceResolver.GetService<ISocketServer>()
-                                .Start(EnumSessionType.Rlogin, rloginPort++, m.ModuleIdentifier);
+                            rloginService = ServiceResolver.GetService<ISocketServer>();
+                            rloginService.Start(EnumSessionType.Rlogin, rloginPort++, m.ModuleIdentifier);
+                            runningServices.Add(rloginService);
                         }
                     }
                 }
@@ -252,6 +266,8 @@ namespace MBBSEmu
                 }
 
                 _logger.Info($"Started MBBSEmu Build #{new ResourceManager().GetString("MBBSEmu.Assets.version.txt")}");
+
+                Console.CancelKeyPress += cancelKeyPressHandler;
             }
             catch (Exception e)
             {
@@ -261,12 +277,30 @@ namespace MBBSEmu
             }
         }
 
+        private void cancelKeyPressHandler(object sender, ConsoleCancelEventArgs args)
+        {
+            // so args.Cancel is a bit strange. Cancel means to cancel to the Ctrl-C processing, so
+            // setting it to true keeps the app alive. We want this at first to allow the shutdown
+            // routines to process naturally. If we get a 2nd (or more) Ctrl-C, then we set
+            // args.Cancel to false which means the app will die a horrible death.
+            args.Cancel = cancellationRequests > 0 ? false : true;
+
+            cancellationRequests++;
+
+            _logger.Warn("BBS Shutting down");
+
+            foreach (var runningService in runningServices)
+            {
+                runningService.Stop();
+            }
+        }
+
         /// <summary>
         ///     Performs a Database Reset
         ///
         ///     Deletes the Accounts Table and sets up a new SYSOP and GUEST user
         /// </summary>
-        private static void DatabaseReset()
+        private void DatabaseReset()
         {
             _logger.Info("Resetting Database...");
             var acct = ServiceResolver.GetService<IAccountRepository>();

--- a/MBBSEmu/Server/IStoppable.cs
+++ b/MBBSEmu/Server/IStoppable.cs
@@ -1,0 +1,13 @@
+using MBBSEmu.Session;
+
+namespace MBBSEmu.Server
+{
+    public interface IStoppable
+    {
+        /// <summary>
+        ///     Requests the object close any persistent resources in a clean manner, such as
+        ///     Threads or Timers.
+        /// </summary>
+        void Stop();
+    }
+}

--- a/MBBSEmu/Server/Socket/ISocketServer.cs
+++ b/MBBSEmu/Server/Socket/ISocketServer.cs
@@ -1,10 +1,10 @@
-﻿using MBBSEmu.Session;
+using MBBSEmu.Server;
+using MBBSEmu.Session;
 
 namespace MBBSEmu.Server.Socket
 {
-    public interface ISocketServer
+    public interface ISocketServer : IStoppable
     {
         void Start(EnumSessionType sessionType, int port, string moduleIdentifier = null);
-        void Stop();
     }
 }

--- a/MBBSEmu/Server/Socket/SocketServer.cs
+++ b/MBBSEmu/Server/Socket/SocketServer.cs
@@ -47,11 +47,18 @@ namespace MBBSEmu.Server.Socket
         public void Stop()
         {
             _listenerSocket.Close();
-            _listenerSocket.Dispose();
         }
 
         private void OnNewConnection(IAsyncResult asyncResult) {
-            System.Net.Sockets.Socket client = _listenerSocket.EndAccept(asyncResult);
+            System.Net.Sockets.Socket client;
+            try
+            {
+                client = _listenerSocket.EndAccept(asyncResult);
+            } catch (ObjectDisposedException) {
+                // ignore, happens during shutdown
+                return;
+            }
+
             client.NoDelay = true;
 
             _listenerSocket.BeginAccept(OnNewConnection, this);
@@ -71,7 +78,6 @@ namespace MBBSEmu.Server.Socket
                             _logger.Info(
                                 $"Rejecting incoming Rlogin connection from unauthorized Remote Host: {client.RemoteEndPoint}");
                             client.Close();
-                            client.Dispose();
                             return;
                         }
 

--- a/MBBSEmu/Session/SessionBase.cs
+++ b/MBBSEmu/Session/SessionBase.cs
@@ -2,6 +2,7 @@ using System;
 using MBBSEmu.HostProcess.Structs;
 using MBBSEmu.Memory;
 using MBBSEmu.Module;
+using MBBSEmu.Server;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -17,7 +18,7 @@ namespace MBBSEmu.Session
     ///     This holds the basics for any given user session, and different source
     ///     (web, telnet, console, etc.) can implement this base.
     /// </summary>
-    public abstract class SessionBase
+    public abstract class SessionBase : IStoppable
     {
         protected delegate void SendToClientDelegate(byte[] dataToSend);
 
@@ -217,6 +218,8 @@ namespace MBBSEmu.Session
         public void SendToClient(string dataToSend) => SendToClient(Encoding.ASCII.GetBytes(dataToSend));
 
         public void SendToClient(ReadOnlySpan<byte> dataToSend) => SendToClient(dataToSend.ToArray());
+
+        public abstract void Stop();
 
         protected SessionBase(string sessionId)
         {

--- a/MBBSEmu/Session/Telnet/TelnetSession.cs
+++ b/MBBSEmu/Session/Telnet/TelnetSession.cs
@@ -139,7 +139,7 @@ namespace MBBSEmu.Session.Telnet
                 byte[] dataToSend;
                 try
                 {
-                    tookData = DataToClient.TryTake(out dataToSend, timeSpan.Milliseconds, _cancellationTokenSource.Token);
+                    tookData = DataToClient.TryTake(out dataToSend, (int) timeSpan.TotalMilliseconds, _cancellationTokenSource.Token);
                 } catch (Exception) // either ObjectDisposedException | OperationCanceledException
                 {
                     return;
@@ -147,7 +147,8 @@ namespace MBBSEmu.Session.Telnet
 
                 if (SessionState == EnumSessionState.LoggingOffProcessing)
                 {
-                    SessionState = EnumSessionState.LoggedOff;
+                    CloseSocket("User-initiated log off");
+                    return;
                 }
 
                 if (SessionTimer.ElapsedMilliseconds >= 500) {


### PR DESCRIPTION
Has the added benefit that logging off with 'x' actually disconnects
the Telnet connection.

One ctrl-c will trigger shutdown and hopefully stop the server. A second
ctrl-c will forcibly kill the server if something doesn't shut down
cleanly.

Calls the `finrou` routine on all modules. Session logoffs also call
the `huprou` routine, though we might want to see if it's more natural
to call `stsrou` instead.