### PR TITLE
New Ordinals

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
@@ -1,0 +1,45 @@
+﻿using MBBSEmu.Memory;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class cncyesno_Tests : MajorbbsTestBase
+    {
+
+        private const int CNCYESNO_ORDINAL = 131;
+
+        [Theory]
+        [InlineData("YES", 'Y', 4)]
+        [InlineData("Y", 'Y', 2)]
+        [InlineData("Y TEST", 'Y', 2)]
+        [InlineData("YES THIS IS A TEST", 'Y', 4)]
+        [InlineData("TEST YES", '\0', 0)]
+        [InlineData("TEST", '\0', 0)]
+        [InlineData("NO", 'N', 3)]
+        [InlineData("N", 'N', 2)]
+        [InlineData("N TEST", 'N', 2)]
+        [InlineData("NO THIS IS A TEST", 'N', 3)]
+        [InlineData("TEST NO", '\0', 0)]
+        
+        public void CNCYESNO_Test(string inputString, char expectedResult, ushort expectedNxtcmdOffset)
+        {
+            //Reset State
+            Reset();
+
+            //Set Input Values
+            mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString.Replace(' ', '\0')));
+            mbbsModule.Memory.SetWord("INPLEN", (ushort)inputString.Length);
+
+            //Execute Test
+            ExecuteApiTest(CNCYESNO_ORDINAL, new List<IntPtr16>());
+
+            //Verify Results
+            var expectedResultPointer = mbbsEmuMemoryCore.GetVariablePointer("INPUT");
+            expectedResultPointer.Offset += expectedNxtcmdOffset;
+            Assert.Equal(expectedResult, mbbsEmuCpuCore.Registers.AX);
+            Assert.Equal(expectedResultPointer, mbbsEmuMemoryCore.GetPointer("NXTCMD"));
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncyesno_Tests.cs
@@ -11,19 +11,25 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int CNCYESNO_ORDINAL = 131;
 
         [Theory]
-        [InlineData("YES", 'Y', 4)]
-        [InlineData("Y", 'Y', 2)]
-        [InlineData("Y TEST", 'Y', 2)]
-        [InlineData("YES THIS IS A TEST", 'Y', 4)]
-        [InlineData("TEST YES", '\0', 0)]
-        [InlineData("TEST", '\0', 0)]
-        [InlineData("NO", 'N', 3)]
-        [InlineData("N", 'N', 2)]
-        [InlineData("N TEST", 'N', 2)]
-        [InlineData("NO THIS IS A TEST", 'N', 3)]
-        [InlineData("TEST NO", '\0', 0)]
-        
-        public void CNCYESNO_Test(string inputString, char expectedResult, ushort expectedNxtcmdOffset)
+
+        //Simple commands with nxtcmd == input
+        [InlineData("YES", 0, 'Y', 4)]
+        [InlineData("Y", 0, 'Y', 2)]
+        [InlineData("Y TEST", 0, 'Y', 2)]
+        [InlineData("YES THIS IS A TEST", 0, 'Y', 4)]
+        [InlineData("TEST YES", 0, 'T', 0)]
+        [InlineData("TEST", 0, 'T', 0)]
+        [InlineData("NO", 0, 'N', 3)]
+        [InlineData("N", 0, 'N', 2)]
+        [InlineData("N TEST", 0, 'N', 2)]
+        [InlineData("NO THIS IS A TEST", 0, 'N', 3)]
+        [InlineData("TEST NO", 0, 'T', 0)]
+
+        //Incremented nxtcmd Tests
+        [InlineData("TEST NO", 5, 'N', 3)]
+        [InlineData("TEST YES", 5, 'Y', 4)]
+        [InlineData("TEST TEST", 5, 'T', 5)]
+        public void CNCYESNO_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, ushort expectedNxtcmdOffset)
         {
             //Reset State
             Reset();
@@ -31,6 +37,11 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Set Input Values
             mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString.Replace(' ', '\0')));
             mbbsModule.Memory.SetWord("INPLEN", (ushort)inputString.Length);
+
+            //Set nxtcmd
+            var currentNxtcmd = mbbsEmuMemoryCore.GetPointer("NXTCMD");
+            currentNxtcmd.Offset += nxtcmdStartingOffset;
+            mbbsEmuMemoryCore.SetPointer("NXTCMD", currentNxtcmd);
 
             //Execute Test
             ExecuteApiTest(CNCYESNO_ORDINAL, new List<IntPtr16>());

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/profan_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/profan_Tests.cs
@@ -1,0 +1,28 @@
+﻿using MBBSEmu.Memory;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class profan_Tests : MajorbbsTestBase
+    {
+
+        private const int PROFAN_ORDINAL = 480;
+
+        [Fact]
+        public void ClingoTests()
+        {
+            //Reset State
+            Reset();
+
+            ExecuteApiTest(PROFAN_ORDINAL, new List<IntPtr16>());
+
+            //Verify Results
+            var returnedPointer = ExecutePropertyTest(PROFAN_ORDINAL);
+
+            var actualValue = mbbsEmuMemoryCore.GetWord(new IntPtr16(returnedPointer));
+
+            Assert.Equal(0, actualValue);
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/profan_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/profan_Tests.cs
@@ -10,7 +10,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int PROFAN_ORDINAL = 480;
 
         [Fact]
-        public void ClingoTests()
+        public void profanTests()
         {
             //Reset State
             Reset();
@@ -18,11 +18,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             ExecuteApiTest(PROFAN_ORDINAL, new List<IntPtr16>());
 
             //Verify Results
-            var returnedPointer = ExecutePropertyTest(PROFAN_ORDINAL);
+            ExecutePropertyTest(PROFAN_ORDINAL);
 
-            var actualValue = mbbsEmuMemoryCore.GetWord(new IntPtr16(returnedPointer));
-
-            Assert.Equal(0, actualValue);
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strlwr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strlwr_Tests.cs
@@ -15,11 +15,31 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("TEST1", "test1")]
         [InlineData("TEST test TEST", "test test test")]
         [InlineData("TeSt", "test")]
-        [InlineData(
-            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void STRLWE_Test(string inputString, string expectedString)
         {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            var string1Pointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(inputString.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(inputString));
+
+            //Execute Test
+            ExecuteApiTest(STRLWR_ORDINAL, new List<IntPtr16> { string1Pointer });
+
+            //Verify Results
+            Assert.Equal(expectedString, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("STRLWR", true)));
+            Assert.Equal(expectedString,
+                Encoding.ASCII.GetString(
+                    mbbsEmuMemoryCore.GetString(new IntPtr16(mbbsEmuCpuRegisters.DX, mbbsEmuCpuRegisters.AX), true)));
+        }
+
+        [Fact]
+        public void STRLWE_Test_1K()
+        {
+            var inputString = new string('A', 1024);
+            var expectedString = new string('a', 1023);
+
             //Reset State
             Reset();
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strlwr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strlwr_Tests.cs
@@ -15,6 +15,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("TEST1", "test1")]
         [InlineData("TEST test TEST", "test test test")]
         [InlineData("TeSt", "test")]
+        [InlineData(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
         public void STRLWE_Test(string inputString, string expectedString)
         {
             //Reset State
@@ -28,8 +31,10 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             ExecuteApiTest(STRLWR_ORDINAL, new List<IntPtr16> { string1Pointer });
 
             //Verify Results
-            var actualResult = Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("STRLWR", true));
-            Assert.Equal(expectedString, actualResult);
+            Assert.Equal(expectedString, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("STRLWR", true)));
+            Assert.Equal(expectedString,
+                Encoding.ASCII.GetString(
+                    mbbsEmuMemoryCore.GetString(new IntPtr16(mbbsEmuCpuRegisters.DX, mbbsEmuCpuRegisters.AX), true)));
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strlwr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strlwr_Tests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MBBSEmu.Memory;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class strlwr_Tests : MajorbbsTestBase
+    {
+        private const int STRLWR_ORDINAL = 579;
+
+        [Theory]
+        [InlineData("TEST", "test")]
+        [InlineData("TEST1", "test1")]
+        [InlineData("TEST test TEST", "test test test")]
+        [InlineData("TeSt", "test")]
+        public void STRLWE_Test(string inputString, string expectedString)
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            var string1Pointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(inputString.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(inputString));
+
+            //Execute Test
+            ExecuteApiTest(STRLWR_ORDINAL, new List<IntPtr16> { string1Pointer });
+
+            //Verify Results
+            var actualResult = Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("STRLWR", true));
+            Assert.Equal(expectedString, actualResult);
+        }
+    }
+}

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -124,10 +124,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         /// <param name="parameterOrdinal"></param>
         /// <returns></returns>
-        private protected string GetParameterString(int parameter)
+        private protected string GetParameterString(int parameterOrdinal, bool stripNull = false)
         {
-            var filenamePointer = GetParameterPointer(parameter);
-            return Encoding.ASCII.GetString(Module.Memory.GetString(filenamePointer, true));
+            var filenamePointer = GetParameterPointer(parameterOrdinal);
+            return Encoding.ASCII.GetString(Module.Memory.GetString(filenamePointer, stripNull));
         }
 
         /// <summary>
@@ -135,9 +135,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         /// <param name="parameterOrdinal"></param>
         /// <returns>The filename parameter, uppercased like DOS expects.</returns>
-        private protected string GetParameterFilename(int parameter)
+        private protected string GetParameterFilename(int parameterOrdinal)
         {
-            return GetParameterString(parameter).ToUpper();
+            return GetParameterString(parameterOrdinal, true).ToUpper();
         }
 
         private static bool InSpan(ReadOnlySpan<char> spanToSearch, ReadOnlySpan<byte> character)

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -88,7 +88,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             Module.Memory.AllocateVariable("OTHUSN", 0x2); //Set by onsys() or instat()
             Module.Memory.AllocateVariable("OTHUSP", 0x4, true);
-            Module.Memory.AllocateVariable("NXTCMD", 0x4); //Holds Pointer to the "next command"
+            Module.Memory.AllocateVariable("NXTCMD", IntPtr16.Size); //Holds Pointer to the "next command"
+            Module.Memory.SetPointer("NXTCMD", Module.Memory.GetVariablePointer("INPUT"));
             Module.Memory.AllocateVariable("NMODS", 0x2); //Number of Modules Installed
             Module.Memory.SetWord("NMODS", 0x1); //set this to 1 for now
             var modulePointer = Module.Memory.AllocateVariable("MODULE", 0x4); //Pointer to Registered Module
@@ -1125,6 +1126,15 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     break;
                 case 1040:
                     ul2as();
+                    break;
+                case 480:
+                    profan();
+                    break;
+                case 131:
+                    cncyesno();
+                    break;
+                case 579:
+                    strlwr();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException($"Unknown Exported Function Ordinal in MAJORBBS: {ordinal}");
@@ -7077,5 +7087,80 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Signature: int errcod;
         /// </summary>
         private ReadOnlySpan<byte> errcod => Module.Memory.GetVariablePointer("ERRCOD").Data;
+
+        /// <summary>
+        ///     Determines the profanity level of a string
+        ///
+        ///     MBBSEmu doesn't support multiple profanity levels, so the default value of 0 is returned.
+        /// 
+        ///     Signature:  int profan(char *string);
+        /// </summary>
+        private void profan()
+        {
+            Registers.AX = 0;
+        }
+
+        /// <summary>
+        ///     Expect a YES or NO from the user
+        ///
+        ///     Signature: int yesno=cncyesno();
+        /// </summary>
+        private void cncyesno()
+        {
+            //Get Input
+            var inputLength = Module.Memory.GetWord("INPLEN");
+            var inputPointer = Module.Memory.GetVariablePointer("INPUT");
+            var inputString = Module.Memory.GetArray(inputPointer, inputLength);
+            var inputStringComponents = Encoding.ASCII.GetString(inputString).ToUpper().Split('\0');
+
+            if (inputStringComponents.Length == 0)
+            {
+                Registers.AX = 0;
+                return;
+            }
+
+            switch (inputStringComponents[0])
+            {
+                case "YES":
+                case "Y":
+                    Registers.AX = 'Y';
+                    break;
+                case "NO":
+                case "N":
+                    Registers.AX = 'N';
+                    break;
+                default:
+                    Registers.AX = 0;
+                    return;
+            }
+
+            Module.Memory.SetPointer("NXTCMD", new IntPtr16(inputPointer.Segment, (ushort)(inputPointer.Offset + inputStringComponents[0].Length + 1)));
+        }
+
+
+        /// <summary>
+        ///     Converts all uppercase letters in the string to lowercase
+        ///
+        ///     Result buffer is 1k
+        ///
+        ///     Signature: char *lower=strlwr(char *string);
+        /// </summary>
+        private void strlwr()
+        {
+            var inputString = GetParameterString(0, false);
+
+            if (inputString.Length > 0x400)
+            {
+                _logger.Error("Input String is larger than the result buffer. String is being truncated to 1k");
+                inputString = inputString.Substring(0, 0x399) + '\0';
+            }
+
+            var destinationPointer = Module.Memory.GetOrAllocateVariablePointer("STRLWR", 0x400);
+
+            Module.Memory.SetArray(destinationPointer, Encoding.ASCII.GetBytes(inputString.ToLower()));
+
+            Registers.AX = destinationPointer.Offset;
+            Registers.DX = destinationPointer.Segment;
+        }
     }
 }


### PR DESCRIPTION
- MAJORBBS.480: profan()
- MAJORBBS.131: cncyesno()
- MAJORBBS.579: strlwr
- Changed GetParameterString() with default value of FALSE for stripNull (same as IMemoryCore method
- Modified GetParameterFilename to pass TRUE for stripNull

Fixes:
https://github.com/enusbaum/MBBSEmu/issues/60
https://github.com/enusbaum/MBBSEmu/issues/59
https://github.com/enusbaum/MBBSEmu/issues/53