### PR TITLE
Tweak sprintf to processor escape characters first instead of last.

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -172,6 +172,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 currentParameter += 2;
             }
 
+            stringToParse = ProcessEscapeCharacters(stringToParse);
+
             for (var i = 0; i < stringToParse.Length; i++)
             {
                 //Handle escaped %% as a single % -- or if % is the last character in a string
@@ -510,7 +512,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 msOutput.WriteByte(stringToParse[i]);
             }
 
-            return ProcessEscapeCharacters(msOutput.ToArray());
+            return msOutput.ToArray();
         }
 
         private protected ReadOnlySpan<byte> StringFromArray(ReadOnlySpan<byte> inputArray, bool stripNull = false)

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -139,7 +139,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.AllocateVariable("**LANGUAGES", IntPtr16.Size);
             Module.Memory.SetPointer("**LANGUAGES", Module.Memory.GetVariablePointer("*LANGUAGES"));
             Module.Memory.AllocateVariable("ERRCOD", sizeof(ushort));
-            
+
 
             var ctypePointer = Module.Memory.AllocateVariable("CTYPE", 0x101);
 
@@ -7058,7 +7058,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     This will always be defaulted to 0 in MBBSEmu, which is ANSI
         ///
-        ///     Signature: int clingo;  
+        ///     Signature: int clingo;
         /// </summary>
         private ReadOnlySpan<byte> clingo => Module.Memory.GetVariablePointer("CLINGO").Data;
 


### PR DESCRIPTION
Fixes the Lunatix issue where it sprintf(buf, "buf\%s") to build a path.
The path ends up being an integer value which crashes the integer
parsing code since it tries to process "buf\1212\1212\1212" when
it really should process the "\%s" first.