### PR TITLE
Fix for cncchr(), cncall(), cncend()

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
@@ -11,12 +11,13 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int CNCCHR_ORDINAL = 122;
 
         [Theory]
-
-        //Simple commands with nxtcmd == input
-        [InlineData("123", 1, '2', 2)]
-        [InlineData("1 2", 0, '1', 2)]
-        [InlineData("2 1", 2, '1', 3)]
-        [InlineData("123 456", 4, '4', 5)]
+        [InlineData(" 123\0", 0, '1', 2)]
+        [InlineData("123\0", 1, '2', 2)]
+        [InlineData("1 2\0", 0, '1', 2)]
+        [InlineData("2 1\0", 2, '1', 3)]
+        [InlineData("123 456\0", 4, '4', 5)]
+        [InlineData("123    456\0", 3, '4', 8)]
+        [InlineData("123\0", 3, '\0', 3)]
         [InlineData("\0", 0, '\0', 0)]
         public void cncchr_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, ushort expectedNxtcmdOffset)
         {
@@ -26,11 +27,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Set Input Values
             var inputLength = (ushort) inputString.Length;
 
-            //parsin() does this check
-            if (inputLength == 1 && inputString[0] == '\0')
-                inputLength = 0;
-
-            mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString.Replace(' ', '\0')));
+            mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString));
             mbbsModule.Memory.SetWord("INPLEN", inputLength);
 
             //Set nxtcmd

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MBBSEmu.Memory;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class cncchr_Tests : MajorbbsTestBase
+    {
+        private const int CNCCHR_ORDINAL = 122;
+
+        [Theory]
+
+        //Simple commands with nxtcmd == input
+        [InlineData("123", 1, '2', 2)]
+        [InlineData("1 2", 0, '1', 2)]
+        [InlineData("2 1", 2, '1', 3)]
+        [InlineData("123 456", 4, '4', 5)]
+        [InlineData("\0", 0, '\0', 0)]
+        public void cncchr_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, ushort expectedNxtcmdOffset)
+        {
+            //Reset State
+            Reset();
+
+            //Set Input Values
+            var inputLength = (ushort) inputString.Length;
+
+            //parsin() does this check
+            if (inputLength == 1 && inputString[0] == '\0')
+                inputLength = 0;
+
+            mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString.Replace(' ', '\0')));
+            mbbsModule.Memory.SetWord("INPLEN", );
+
+            //Set nxtcmd
+            var currentNxtcmd = mbbsEmuMemoryCore.GetPointer("NXTCMD");
+            currentNxtcmd.Offset += nxtcmdStartingOffset;
+            mbbsEmuMemoryCore.SetPointer("NXTCMD", currentNxtcmd);
+
+            //Execute Test
+            ExecuteApiTest(CNCCHR_ORDINAL, new List<IntPtr16>());
+
+            //Verify Results
+            var expectedResultPointer = mbbsEmuMemoryCore.GetVariablePointer("INPUT");
+            expectedResultPointer.Offset += expectedNxtcmdOffset;
+            Assert.Equal(expectedResult, mbbsEmuCpuCore.Registers.AX);
+            Assert.Equal(expectedResultPointer, mbbsEmuMemoryCore.GetPointer("NXTCMD"));
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/cncchr_Tests.cs
@@ -31,7 +31,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
                 inputLength = 0;
 
             mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString.Replace(' ', '\0')));
-            mbbsModule.Memory.SetWord("INPLEN", );
+            mbbsModule.Memory.SetWord("INPLEN", inputLength);
 
             //Set nxtcmd
             var currentNxtcmd = mbbsEmuMemoryCore.GetPointer("NXTCMD");

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/endcnc_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/endcnc_Tests.cs
@@ -15,6 +15,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("123 ABC\0", 1, 0, "23\0ABC\0", 2)]
         [InlineData("123 ABC\0", 3, 0, "ABC\0", 1)]
         [InlineData("123 ABC\0", 4, 0, "ABC\0", 1)]
+        [InlineData("123 ABC\0", 5, 0, "BC\0", 1)]
         [InlineData("\0", 0, 1, "", 0)]
         public void endcnc_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, string expectedInputString, ushort expectedMargc)
         {

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/endcnc_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/endcnc_Tests.cs
@@ -1,0 +1,48 @@
+﻿using MBBSEmu.Memory;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class endcnc_Tests : MajorbbsTestBase
+    {
+        private const int ENDCNC_ORDINAL = 191;
+
+        [Theory]
+
+        //Simple commands with nxtcmd == input
+        [InlineData("123 ABC\0", 1, 0, "23\0ABC\0", 2)]
+        [InlineData("123 ABC\0", 3, 0, "ABC\0", 1)]
+        [InlineData("123 ABC\0", 4, 0, "ABC\0", 1)]
+        [InlineData("\0", 0, 1, "", 0)]
+        public void endcnc_Test(string inputString, ushort nxtcmdStartingOffset, char expectedResult, string expectedInputString, ushort expectedMargc)
+        {
+            //Reset State
+            Reset();
+
+            //Set Input Values
+            var inputLength = (ushort)inputString.Length;
+
+            mbbsModule.Memory.SetArray("INPUT", Encoding.ASCII.GetBytes(inputString));
+            mbbsModule.Memory.SetWord("INPLEN", inputLength);
+
+            //Set nxtcmd
+            var currentNxtcmd = mbbsEmuMemoryCore.GetPointer("NXTCMD");
+            currentNxtcmd.Offset += nxtcmdStartingOffset;
+            mbbsEmuMemoryCore.SetPointer("NXTCMD", currentNxtcmd);
+
+            //Execute Test
+            ExecuteApiTest(ENDCNC_ORDINAL, new List<IntPtr16>());
+
+            //Gather Results
+            var actualResult = mbbsEmuCpuCore.Registers.AX;
+            var actualInputString = Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetArray("INPUT", mbbsEmuMemoryCore.GetWord("INPLEN")));
+            var actualMargc = mbbsEmuMemoryCore.GetWord("MARGC");
+            //Verify Results
+            Assert.Equal(expectedInputString, actualInputString);
+            Assert.Equal(expectedResult, actualResult);
+            Assert.Equal(expectedMargc, actualMargc);
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/parsin_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/parsin_Tests.cs
@@ -1,0 +1,61 @@
+﻿using MBBSEmu.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class parsin_Tests : MajorbbsTestBase
+    {
+        private const ushort PARSIN_ORDINAL = 467;
+
+        [Theory]
+        [InlineData("TEST1 TEST2 TEST3\0", 3, 18)]
+        [InlineData("\0", 0, 0)]
+        [InlineData("A B\0", 2, 4)]
+        [InlineData("A TEST B\0", 3, 9)]
+        public void parsin_Test(string inputCommand, int expectedMargc, int expectedInputLength)
+        {
+            //Reset State
+            Reset();
+
+            //Set Input Values
+            mbbsEmuMemoryCore.SetArray("INPUT", Encoding.ASCII.GetBytes(inputCommand));
+            mbbsEmuMemoryCore.SetWord("INPLEN", (ushort)inputCommand.Length);
+
+            ExecuteApiTest(PARSIN_ORDINAL, new List<IntPtr16>());
+
+            //Verify Results
+            var actualInputLength = mbbsEmuMemoryCore.GetWord("INPLEN");
+            var actualMargc = mbbsEmuMemoryCore.GetWord("MARGC");
+
+            Assert.Equal(expectedMargc, actualMargc); //Verify Correct Number of Commands Parsed
+            Assert.Equal(expectedInputLength, actualInputLength); //Verify Length is Correct
+            Assert.True(Encoding.ASCII.GetBytes(inputCommand.Replace(' ', '\0'))
+                .SequenceEqual(mbbsEmuMemoryCore.GetArray("INPUT", (ushort) inputCommand.Length).ToArray())); //Verify spaces replaced with nulls
+
+            //Verify Argument Addresses
+
+            //Replicate parsin() by replacing space with nulls, then get string components
+            var inputComponents = inputCommand.Replace(' ', '\0').Split('\0', StringSplitOptions.RemoveEmptyEntries);
+
+            //Get Argument Starting Points
+            var margvPointer = mbbsEmuMemoryCore.GetVariablePointer("MARGV");
+            var margnPointer = mbbsEmuMemoryCore.GetVariablePointer("MARGN");
+
+            for (var i = 0; i < expectedMargc; i++)
+            {
+                var currentMargvPointer = mbbsEmuMemoryCore.GetPointer(margvPointer.Segment, (ushort)(margvPointer.Offset + (ushort)(i * IntPtr16.Size)));
+                var currentMargnPointer = mbbsEmuMemoryCore.GetPointer(margnPointer.Segment, (ushort)(margnPointer.Offset + (ushort)(i * IntPtr16.Size)));
+
+                //Since we split the input on null, we'll strip null from the string
+                var currentArg = Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString(currentMargvPointer, true));
+
+                Assert.Equal(inputComponents[i], currentArg);
+                Assert.Equal(inputComponents[i].Length, currentMargnPointer.Offset - currentMargvPointer.Offset);
+            }
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rstrin_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rstrin_Tests.cs
@@ -1,0 +1,37 @@
+﻿using MBBSEmu.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class rstrin_Tests : MajorbbsTestBase
+    {
+        private const ushort RSTRIN_ORDINAL = 511;
+
+        [Theory]
+        [InlineData("TEST1\0TEST2\0TEST3\0")]
+        [InlineData("\0")]
+        [InlineData("A\0B\0")]
+        [InlineData("A\0TEST\0B\0")]
+        public void rstrin_Test(string inputCommand)
+        {
+            //Reset State
+            Reset();
+
+            //Set Input Values
+            mbbsEmuMemoryCore.SetArray("INPUT", Encoding.ASCII.GetBytes(inputCommand));
+            mbbsEmuMemoryCore.SetWord("INPLEN", (ushort)inputCommand.Length);
+
+            ExecuteApiTest(RSTRIN_ORDINAL, new List<IntPtr16>());
+
+            //Verify Results
+            //Simulate rstrin by replacing nulls with spaces, ensuring last character is null
+            var expectedRstrin = inputCommand.Replace('\0', ' ').TrimEnd() + '\0';
+            Assert.True(Encoding.ASCII.GetBytes(expectedRstrin)
+                .SequenceEqual(mbbsEmuMemoryCore.GetArray("INPUT", (ushort)inputCommand.Length).ToArray())); //Verify spaces replaced with nulls
+        }
+    }
+}

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -140,7 +140,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.AllocateVariable("**LANGUAGES", IntPtr16.Size);
             Module.Memory.SetPointer("**LANGUAGES", Module.Memory.GetVariablePointer("*LANGUAGES"));
             Module.Memory.AllocateVariable("ERRCOD", sizeof(ushort));
-            
+
 
             var ctypePointer = Module.Memory.AllocateVariable("CTYPE", 0x101);
 
@@ -3357,7 +3357,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             for (var i = inputPointer.Offset; i < inputPointer.Offset + (inputLength - 1); i++)
             {
-                if(Module.Memory.GetByte(inputPointer.Segment, i) == 0)
+                if (Module.Memory.GetByte(inputPointer.Segment, i) == 0)
                     Module.Memory.SetByte(inputPointer.Segment, i, 0x20);
             }
         }
@@ -3836,7 +3836,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var inputLength = Module.Memory.GetWord("INPLEN");
 
             //If Length is 0, there's nothing to process
-            if(Module.Memory.GetByte(inputPointer) == 0)
+            if (Module.Memory.GetByte(inputPointer) == 0)
             {
                 Module.Memory.SetWord("INPLEN", 0);
                 Module.Memory.SetWord("MARGC", 0);
@@ -3859,7 +3859,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 if (currentInputByte != 0x20 && currentInputByte != 0x0) continue;
 
                 Module.Memory.SetByte(inputPointer.Segment, i, 0x0); //replace space with null
-                    
+
                 //Set Command End
                 var commandEndPointer = new IntPtr16(inputPointer.Segment, i);
                 Module.Memory.SetPointer(margnPointer, commandEndPointer);
@@ -4147,10 +4147,13 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var stringToFind = Encoding.ASCII.GetString(Module.Memory.GetString(stringToFindPointer, true));
 
             var offset = stringToSearch.IndexOf(stringToFind);
-            if (offset >= 0) {
+            if (offset >= 0)
+            {
                 Registers.AX = (ushort)(stringToSearchPointer.Offset + offset);
                 Registers.DX = stringToSearchPointer.Segment;
-            } else {
+            }
+            else
+            {
                 // not found, return NULL
                 Registers.AX = 0;
                 Registers.DX = 0;
@@ -5326,7 +5329,27 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var remainingCharactersInCommand = inputLength - (nxtcmdPointer.Offset - inputPointer.Offset);
 
-            Registers.AX = remainingCharactersInCommand == 0 ? (ushort) 1 : (ushort) 0;
+            //Check to see if nxtcmd is on a space, if so, increment it by 1
+            if (Module.Memory.GetByte(nxtcmdPointer) == 0x20)
+            {
+                remainingCharactersInCommand--;
+                nxtcmdPointer.Offset++;
+            }
+
+            //End of String
+            if (Module.Memory.GetByte(nxtcmdPointer) == 0)
+            {
+                remainingCharactersInCommand = 0;
+            }
+
+            //Get Remaining Characters & Save to Input
+            var remainingInput = Module.Memory.GetArray(nxtcmdPointer, (ushort)(remainingCharactersInCommand));
+            Module.Memory.SetArray(inputPointer, remainingInput);
+            Module.Memory.SetWord("INPLEN", (ushort)remainingCharactersInCommand);
+            Module.Memory.SetPointer("NXTCMD", inputPointer);
+            parsin();
+
+            Registers.AX = remainingCharactersInCommand == 0 ? (ushort)1 : (ushort)0;
         }
 
         /// <summary>
@@ -5367,7 +5390,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             rstrin();
 
             var inputPointer = Module.Memory.GetVariablePointer("INPUT");
-            var inputLength =  Module.Memory.GetWord("INPLEN");
+            var inputLength = Module.Memory.GetWord("INPLEN");
 
             var newNxtcmd = new IntPtr16(inputPointer.Segment, (ushort)(inputPointer.Offset + inputLength));
 
@@ -7020,7 +7043,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var currentBtrieveFile = BtrievePointerDictionaryNew[_currentBtrieveFile];
 
-            var record = currentBtrieveFile.GetRecord((uint) absolutePosition);
+            var record = currentBtrieveFile.GetRecord((uint)absolutePosition);
 
             if (record != null)
             {

--- a/MBBSEmu/Session/SessionBase.cs
+++ b/MBBSEmu/Session/SessionBase.cs
@@ -112,21 +112,6 @@ namespace MBBSEmu.Session
         public byte PromptCharacter { get; set; }
 
         /// <summary>
-        ///     Total Number of Commands Passed in from user input by parsin()
-        /// </summary>
-        public int mArgCount { get; set; }
-
-        /// <summary>
-        ///     Pointers to the START of each command
-        /// </summary>
-        public List<int> mArgv { get; set; }
-
-        /// <summary>
-        ///     Pointers to the END of each command
-        /// </summary>
-        public List<int> mArgn { get; set; }
-
-        /// <summary>
         ///     Queue to hold data to be sent async to Client
         /// </summary>
         public BlockingCollection<byte[]> DataToClient { get; set; }
@@ -238,60 +223,6 @@ namespace MBBSEmu.Session
             InputBuffer = new MemoryStream();
 
             InputCommand = new byte[] { 0x0 };
-            mArgn = new List<int>();
-            mArgv = new List<int>();
-        }
-
-        /// <summary>
-        ///     Routine Parses the data in the input buffer, builds the command input string
-        ///     and assembles all the mArgs
-        /// </summary>
-        public void parsin()
-        {
-            mArgv.Clear();
-            mArgn.Clear();
-
-            if (InputCommand == null || InputCommand.Length == 0 || InputCommand[0] == 0x0)
-            {
-                mArgCount = 0;
-                return;
-            }
-
-            mArgv.Add(0);
-
-            //Input Command has spaces replaced by null characters
-            for (ushort i = 0; i < InputCommand.Length; i++)
-            {
-                //We only parse command character on space, otherwise just copy
-                if (InputCommand[i] != 0x20)
-                    continue;
-
-                //Replace the space with null
-                InputCommand[i] = 0x0;
-
-                mArgn.Add(i);
-
-                if (i + 1 < InputCommand.Length)
-                    mArgv.Add(i + 1);
-            }
-            mArgn.Add((int)(InputBuffer.Length - 1));
-            mArgCount = mArgn.Count;
-        }
-
-        /// <summary>
-        ///     Restores the Input Command back to it's unparsed date (NULL to spaces)
-        /// </summary>
-        public void rstrin()
-        {
-            //This usually hits on first entry if it's called
-            if (InputCommand == null)
-                return;
-
-            for (var i = 0; i < InputCommand.Length - 1; i++)
-            {
-                if (InputCommand[i] == 0x0)
-                    InputCommand[i] = 0x20;
-            }
         }
 
         public void ProcessDataFromClient()


### PR DESCRIPTION
- Moved `parsin` and `rstrin` into `MAJORBBS` out of the session base
- Simplified INPUT setting and handling when processing a command (STATUS ==3)

Fixes https://github.com/enusbaum/MBBSEmu/issues/55