### PR TITLE
Fixes for T-LORD (RTSLORD) and String Handling

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strcpy_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strcpy_Tests.cs
@@ -13,6 +13,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("TEST1\0", "TEST1\0")]
         [InlineData("TEST1\0TEST2\0", "TEST1\0")]
         [InlineData("\0", "\0")]
+        [InlineData("", "\0")]
         public void strcpy_Test(string sourceString, string expectedDestination)
         {
             //Reset State
@@ -21,9 +22,14 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Set Argument Values to be Passed In
             var destinationStringPointer = mbbsEmuMemoryCore.AllocateVariable("DESTINATION_STRING", 0xFF);
             mbbsEmuMemoryCore.SetArray("DESTINATION_STRING", Encoding.ASCII.GetBytes(new string('X', 0xFF)));
-            var sourceStringPointer = mbbsEmuMemoryCore.AllocateVariable("SOURCE_STRING", (ushort)(sourceString.Length + 1));
-            mbbsEmuMemoryCore.SetArray("SOURCE_STRING", Encoding.ASCII.GetBytes(sourceString));
-            
+
+            var sourceStringPointer = IntPtr16.Empty;
+            if (!string.IsNullOrEmpty(sourceString))
+            {
+                sourceStringPointer = mbbsEmuMemoryCore.AllocateVariable("SOURCE_STRING", (ushort)(sourceString.Length + 1));
+                mbbsEmuMemoryCore.SetArray("SOURCE_STRING", Encoding.ASCII.GetBytes(sourceString));
+            }
+
 
             //Execute Test
             ExecuteApiTest(STRCPY_ORDINAL, new List<IntPtr16> { destinationStringPointer, sourceStringPointer });

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/strcpy_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/strcpy_Tests.cs
@@ -1,0 +1,35 @@
+﻿using MBBSEmu.Memory;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class strcpy_Tests : MajorbbsTestBase
+    {
+        private const int STRCPY_ORDINAL = 574;
+
+        [Theory]
+        [InlineData("TEST1\0", "TEST1\0")]
+        [InlineData("TEST1\0TEST2\0", "TEST1\0")]
+        [InlineData("\0", "\0")]
+        public void strcpy_Test(string sourceString, string expectedDestination)
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            var destinationStringPointer = mbbsEmuMemoryCore.AllocateVariable("DESTINATION_STRING", 0xFF);
+            mbbsEmuMemoryCore.SetArray("DESTINATION_STRING", Encoding.ASCII.GetBytes(new string('X', 0xFF)));
+            var sourceStringPointer = mbbsEmuMemoryCore.AllocateVariable("SOURCE_STRING", (ushort)(sourceString.Length + 1));
+            mbbsEmuMemoryCore.SetArray("SOURCE_STRING", Encoding.ASCII.GetBytes(sourceString));
+            
+
+            //Execute Test
+            ExecuteApiTest(STRCPY_ORDINAL, new List<IntPtr16> { destinationStringPointer, sourceStringPointer });
+
+            //Verify Results
+            Assert.Equal(expectedDestination, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("DESTINATION_STRING")));
+        }
+    }
+}

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -1235,6 +1235,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             }
             else
             {
+                Module.Memory.SetByte(destinationPointer, 0);
 #if DEBUG
                 _logger.Warn($"Ignoring, source ({sourcePointer}) is NULL");
 #endif
@@ -1725,6 +1726,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             //Set prfptr to the base address of prfbuf
             Module.Memory.SetPointer("PRFPTR", Module.Memory.GetVariablePointer("PRFBUF"));
+            Module.Memory.SetByte(Module.Memory.GetVariablePointer("PRFBUF"), 0);
 
 #if DEBUG
             _logger.Info("Reset Output Buffer");
@@ -3645,10 +3647,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
             {
                 var inputValue = (byte)fileStream.ReadByte();
 
+                valueFromFile.WriteByte(inputValue);
+
                 if (inputValue == '\n' || fileStream.Position == fileStream.Length)
                     break;
-
-                valueFromFile.WriteByte(inputValue);
             }
 
             valueFromFile.WriteByte(0);

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -1224,20 +1224,18 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var inputBuffer = Module.Memory.GetString(sourcePointer);
 
-            if (inputBuffer[0] != 0x0)
+            if (inputBuffer[0] == 0x0 || sourcePointer == IntPtr16.Empty)
             {
-                Module.Memory.SetArray(destinationPointer, inputBuffer);
-
+                Module.Memory.SetByte(destinationPointer, 0);
 #if DEBUG
-                _logger.Info($"Copied {inputBuffer.Length} bytes from {sourcePointer} to {destinationPointer} -> {Encoding.ASCII.GetString(inputBuffer)}");
-                // _logger.Info($"Copied {inputBuffer.Length} bytes from {sourcePointer} to {destinationPointer}");
+                _logger.Warn($"Source ({sourcePointer}) is NULL");
 #endif
             }
             else
             {
-                Module.Memory.SetByte(destinationPointer, 0);
+                Module.Memory.SetArray(destinationPointer, inputBuffer);
 #if DEBUG
-                _logger.Warn($"Ignoring, source ({sourcePointer}) is NULL");
+                //_logger.Info($"Copied {inputBuffer.Length} bytes from {sourcePointer} to {destinationPointer} -> {Encoding.ASCII.GetString(inputBuffer)}");
 #endif
             }
 
@@ -3860,7 +3858,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             }
 
             //Parse out the Input, eliminating excess spaces and separating words by null
-            var inputComponents  = Encoding.ASCII.GetString(Module.Memory.GetString("INPUT"))
+            var inputComponents = Encoding.ASCII.GetString(Module.Memory.GetString("INPUT"))
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var parsedInput = string.Join('\0', inputComponents);
 
@@ -3868,14 +3866,14 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var margvPointer = new IntPtr16(Module.Memory.GetVariablePointer("MARGV"));
             var margnPointer = new IntPtr16(Module.Memory.GetVariablePointer("MARGN"));
 
-            var margCount = (ushort) inputComponents.Length;
+            var margCount = (ushort)inputComponents.Length;
 
             Module.Memory.SetPointer(margvPointer, inputPointer); //Set 1st command to start at start of input
             margvPointer.Offset += IntPtr16.Size;
 
             for (var i = 0; i < parsedInput.Length; i++)
             {
-                if(parsedInput[i] != 0)
+                if (parsedInput[i] != 0)
                     continue;
 
                 //Set Command End


### PR DESCRIPTION
1. clrprf() writes null (0x0) to PRFBUF to ensure the string is null
2. strcpy() copies null (0x0) to the destination if the source is null
3. fgets() includes the last character read when encoutering \n or last byte in the file

Fixes #49 