### PR TITLE
Fixed parsin() to retain white spaces from the user input

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/parsin_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/parsin_Tests.cs
@@ -16,8 +16,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("\0", 0, 0)]
         [InlineData("A B\0", 2, 4)]
         [InlineData("A TEST B\0", 3, 9)]
-        [InlineData("A      TEST       B\0", 3, 9)]
-        [InlineData("A   TEST                        B\0", 3, 9)]
+        [InlineData("A      TEST       B\0", 3, 20)]
+        [InlineData("A   TEST                        B\0", 3, 34)]
         public void parsin_Test(string inputCommand, int expectedMargc, int expectedInputLength)
         {
             //Reset State
@@ -30,7 +30,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             ExecuteApiTest(PARSIN_ORDINAL, new List<IntPtr16>());
 
             //Verify Results
-            var expectedParsedInput = Encoding.ASCII.GetBytes(string.Join('\0', inputCommand.Split(' ', StringSplitOptions.RemoveEmptyEntries)));
+            var expectedParsedInput = Encoding.ASCII.GetBytes(inputCommand.Replace(' ', '\0'));
             var actualInputLength = mbbsEmuMemoryCore.GetWord("INPLEN");
             var actualMargc = mbbsEmuMemoryCore.GetWord("MARGC");
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/rstrin_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/rstrin_Tests.cs
@@ -16,6 +16,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("\0")]
         [InlineData("A\0B\0")]
         [InlineData("A\0TEST\0B\0")]
+        [InlineData("A\0\0\0TEST\0\0\0B\0")]
         public void rstrin_Test(string inputCommand)
         {
             //Reset State

--- a/MBBSEmu.Tests/Integration/Echo_Tests.cs
+++ b/MBBSEmu.Tests/Integration/Echo_Tests.cs
@@ -6,7 +6,7 @@ namespace MBBSEmu.Tests.Integration
     public class Echo_Tests : MBBSEmuIntegrationTestBase
     {
         [Fact]
-        public void doEchoTestAndLogOff()
+        public void DoEchoTestAndLogOff()
         {
             ExecuteTest(session => {
                 WaitUntil(':', "Make your selection");
@@ -19,6 +19,30 @@ namespace MBBSEmu.Tests.Integration
 
                 WaitUntil(':', "You entered");
                 WaitUntil('\n', "This is really cool!");
+
+                session.SendToModule(Encoding.ASCII.GetBytes("x\r\nx\r\nx\r\nY\r\n"));
+
+                WaitUntil('.', "Have a nice day");
+            });
+        }
+
+        /// <summary>
+        ///     Tests to ensure Parsin maintains spaces end-to-end when processing input
+        /// </summary>
+        [Fact]
+        public void ParsinMaintainSpaces()
+        {
+            ExecuteTest(session => {
+                WaitUntil(':', "Make your selection");
+
+                session.SendToModule(Encoding.ASCII.GetBytes("E\r\n"));
+
+                WaitUntil(':', "Type something");
+
+                session.SendToModule(Encoding.ASCII.GetBytes("Test    Spaces\r\n"));
+
+                WaitUntil(':', "You entered");
+                WaitUntil('\n', "Test    Spaces");
 
                 session.SendToModule(Encoding.ASCII.GetBytes("x\r\nx\r\nx\r\nY\r\n"));
 

--- a/MBBSEmu.Tests/Integration/MBBSEmuIntegrationTestBase.cs
+++ b/MBBSEmu.Tests/Integration/MBBSEmuIntegrationTestBase.cs
@@ -24,7 +24,7 @@ namespace MBBSEmu.Tests.Integration
 
         public void Dispose()
         {
-            Directory.Delete(_modulePath, /* recursive= */ true);
+            Directory.Delete(_modulePath,  recursive: true);
         }
 
         private void CopyModuleToTempPath(IResourceManager resourceManager)
@@ -72,8 +72,10 @@ namespace MBBSEmu.Tests.Integration
 
             CopyModuleToTempPath(ResourceManager.GetTestResourceManager());
 
-            var modules = new List<MbbsModule>();
-            modules.Add(new MbbsModule(ServiceResolver.GetService<IFileUtility>(), "MBBSEMU", _modulePath));
+            var modules = new List<MbbsModule>
+            {
+                new MbbsModule(ServiceResolver.GetService<IFileUtility>(), "MBBSEMU", _modulePath)
+            };
 
             //Setup and Run Host
             var host = ServiceResolver.GetService<IMbbsHost>();

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3859,14 +3859,14 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             //Parse out the Input, eliminating excess spaces and separating words by null
             var inputComponents = Encoding.ASCII.GetString(Module.Memory.GetString("INPUT"))
-                .Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                .Split(' ');
             var parsedInput = string.Join('\0', inputComponents);
 
             //Setup MARGV & MARGN
             var margvPointer = new IntPtr16(Module.Memory.GetVariablePointer("MARGV"));
             var margnPointer = new IntPtr16(Module.Memory.GetVariablePointer("MARGN"));
 
-            var margCount = (ushort)inputComponents.Length;
+            var margCount = (ushort)inputComponents.Count(x => !string.IsNullOrEmpty(x));
 
             Module.Memory.SetPointer(margvPointer, inputPointer); //Set 1st command to start at start of input
             margvPointer.Offset += IntPtr16.Size;
@@ -3882,6 +3882,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 margnPointer.Offset += IntPtr16.Size;
 
                 i++;
+
+                //Skip any white spaces after the current command
+                while (i < parsedInput.Length && parsedInput[i] == 0)
+                    i++;
 
                 //Are we at the end of the INPUT? If so, we're done here.
                 if (i == parsedInput.Length)

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -298,12 +298,21 @@ namespace MBBSEmu.HostProcess
             _logger.Info("SHUTTING DOWN");
 
             // kill all active sessions
-            foreach (SessionBase session in _channelDictionary.Values) {
+            foreach (var session in _channelDictionary.Values) {
                 session.Stop();
             }
 
             // let modules clean themselves up
             CallModuleRoutine("finrou", module => _logger.Info($"Calling shutdown routine on module {module.ModuleIdentifier}"));
+
+            //clean up modules
+            foreach (var m in _modules.Keys)
+            {
+                _modules.Remove(m);
+
+                foreach (var e in _exportedFunctions.Keys.Where(x => x.StartsWith(m)))
+                    _exportedFunctions.Remove(e);
+            }
         }
 
         private void CallModuleRoutine(string routine, Action<MbbsModule> preRunCallback, ushort channel = ushort.MaxValue) {


### PR DESCRIPTION
Fixes #87 

parsin() retains the spaces (replaced with nulls), and margn/v is set to the non-null commands within the string.