### PR TITLE
Added HEXOPT Ordinal & Testing Enhancements

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/hexopt_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/hexopt_Tests.cs
@@ -1,4 +1,5 @@
-﻿using MBBSEmu.Module;
+﻿using System;
+using MBBSEmu.Module;
 using System.Collections.Generic;
 using System.Text;
 using MBBSEmu.Memory;
@@ -11,21 +12,29 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int HEXOPT_ORDINAL = 339;
 
         [Theory]
-        [InlineData("FF", 255, 0, 256)]
-        [InlineData("FFFF", ushort.MaxValue, 0, ushort.MaxValue)]
-        [InlineData("0", 0, 0, ushort.MaxValue)]
-        [InlineData("F", 15, 0, ushort.MaxValue)]
-        public void hexopt_Test(string input, ushort expectedValue, ushort min, ushort max)
+        [InlineData("FF", 255, 0, 256, false)]
+        [InlineData("FFFF", ushort.MaxValue, 0, ushort.MaxValue, false)]
+        [InlineData("0", 0, 0, ushort.MaxValue, false)]
+        [InlineData("F", 15, 0, ushort.MaxValue, false)]
+        [InlineData("F", 0, 16, ushort.MaxValue, true)] //min test
+        [InlineData("F", 0, 0, 1, true)] //max test
+        public void hexopt_Test(string input, ushort expectedValue, ushort min, ushort max, bool shouldThrowException)
         {
             //Reset State
             Reset();
 
             var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
-                new Dictionary<int, byte[]> {{0, Encoding.ASCII.GetBytes(input)}}));
+                new Dictionary<int, byte[]> { { 0, Encoding.ASCII.GetBytes(input) } }));
 
             mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new IntPtr16(0xFFFF, mcvPointer));
-
-            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HEXOPT_ORDINAL, new List<ushort> { 0, min, max });
+            try
+            {
+                ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HEXOPT_ORDINAL, new List<ushort> { 0, min, max });
+            }
+            catch (Exception)
+            {
+                Assert.True(shouldThrowException);
+            }
 
             //Verify Results
             Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/hexopt_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/hexopt_Tests.cs
@@ -1,0 +1,34 @@
+﻿using MBBSEmu.Module;
+using System.Collections.Generic;
+using System.Text;
+using MBBSEmu.Memory;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class hexopt_Tests : ExportedModuleTestBase
+    {
+        private const int HEXOPT_ORDINAL = 339;
+
+        [Theory]
+        [InlineData("FF", 255, 0, 256)]
+        [InlineData("FFFF", ushort.MaxValue, 0, ushort.MaxValue)]
+        [InlineData("0", 0, 0, ushort.MaxValue)]
+        [InlineData("F", 15, 0, ushort.MaxValue)]
+        public void hexopt_Test(string input, ushort expectedValue, ushort min, ushort max)
+        {
+            //Reset State
+            Reset();
+
+            var mcvPointer = (ushort)majorbbs.McvPointerDictionary.Allocate(new McvFile("TEST.MCV",
+                new Dictionary<int, byte[]> {{0, Encoding.ASCII.GetBytes(input)}}));
+
+            mbbsEmuMemoryCore.SetPointer("CURRENT-MCV", new IntPtr16(0xFFFF, mcvPointer));
+
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HEXOPT_ORDINAL, new List<ushort> { 0, min, max });
+
+            //Verify Results
+            Assert.Equal(expectedValue, mbbsEmuCpuRegisters.AX);
+        }
+    }
+}

--- a/MBBSEmu/HostProcess/ExecutionUnits/ExecutionUnit.cs
+++ b/MBBSEmu/HostProcess/ExecutionUnits/ExecutionUnit.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using MBBSEmu.CPU;
 using MBBSEmu.HostProcess.ExportedModules;
 using MBBSEmu.Memory;
+using NLog;
 
 namespace MBBSEmu.HostProcess.ExecutionUnits
 {
@@ -32,9 +33,9 @@ namespace MBBSEmu.HostProcess.ExecutionUnits
         /// </summary>
         public readonly Dictionary<ushort, IExportedModule> ExportedModuleDictionary;
 
-        public ExecutionUnit(IMemoryCore moduleMemory, Dictionary<ushort, IExportedModule> exportedModuleDictionary)
+        public ExecutionUnit(IMemoryCore moduleMemory, Dictionary<ushort, IExportedModule> exportedModuleDictionary, ILogger logger)
         {
-            ModuleCpu = new CpuCore();
+            ModuleCpu = new CpuCore(logger);
             ModuleCpuRegisters = new CpuRegisters();
             ModuleMemory = moduleMemory;
             ExportedModuleDictionary = exportedModuleDictionary;

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -8,7 +8,6 @@ using MBBSEmu.Session;
 using Microsoft.Extensions.Configuration;
 using NLog;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -34,7 +33,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Pointers to files opened using FOPEN
         /// </summary>
         private protected readonly PointerDictionary<FileStream> FilePointerDictionary;
-        private protected readonly PointerDictionary<McvFile> McvPointerDictionary;
+        public readonly PointerDictionary<McvFile> McvPointerDictionary;
 
         private protected readonly ILogger _logger;
         private protected readonly IConfiguration _configuration;

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -573,7 +573,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     case var textVariableName when Module.TextVariables.ContainsKey(textVariableName):
                         //Get Variable Entry Point
                         var variableEntryPoint = Module.TextVariables[textVariableName];
-                        var resultRegisters = Module.Execute(variableEntryPoint, ChannelNumber, true, true);
+                        var resultRegisters = Module.Execute(variableEntryPoint, ChannelNumber, true, true, null, 0xF100);
                         var variableData = Module.Memory.GetString(resultRegisters.DX, resultRegisters.AX, true);
 #if DEBUG
                         _logger.Info($"Processing Text Variable {textVariableName} ({variableEntryPoint}): {BitConverter.ToString(variableData.ToArray()).Replace("-", " ")}");

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -28,7 +28,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
     {
         public IntPtr16 GlobalCommandHandler;
 
-        private IntPtr16 _currentMcvFile;
+        private IntPtr16 _currentMcvFile
+        {
+            get => Module.Memory.GetPointer("CURRENT-MCV");
+            set => Module.Memory.SetPointer("CURRENT-MCV", value);
+        }
         private readonly Stack<IntPtr16> _previousMcvFile;
 
         private readonly Stack<IntPtr16> _previousBtrieveFile;
@@ -143,7 +147,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.AllocateVariable("**LANGUAGES", IntPtr16.Size);
             Module.Memory.SetPointer("**LANGUAGES", Module.Memory.GetVariablePointer("*LANGUAGES"));
             Module.Memory.AllocateVariable("ERRCOD", sizeof(ushort));
-
+            Module.Memory.AllocateVariable("CURRENT-MCV", IntPtr16.Size);
 
             var ctypePointer = Module.Memory.AllocateVariable("CTYPE", 0x101);
 
@@ -1129,6 +1133,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     break;
                 case 127:
                     cncnum();
+                    break;
+                case 339:
+                    hexopt();
                     break;
                 default:
                     throw new ArgumentOutOfRangeException($"Unknown Exported Function Ordinal in MAJORBBS: {ordinal}");
@@ -7405,6 +7412,32 @@ namespace MBBSEmu.HostProcess.ExportedModules
             }
 
             Module.Memory.SetPointer("NXTCMD", new IntPtr16(nxtcmdPointer.Segment, (ushort)(nxtcmdPointer.Offset)));
+        }
+
+
+        /// <summary>
+        ///     Retrieves a Hex value as Numeric option from MCV file
+        ///
+        ///     Signature: unsigned hexopt(int msgnum,unsigned floor,unsigned ceiling);
+        ///     Return: AX = Value retrieved
+        /// </summary>
+        private void hexopt()
+        {
+            var msgnum = GetParameter(0);
+            var floor = (short)GetParameter(1);
+            var ceiling = GetParameter(2);
+
+            var outputValue = McvPointerDictionary[_currentMcvFile.Offset].GetHex(msgnum);
+
+            //Validate
+            if (outputValue < floor || outputValue > ceiling)
+                throw new ArgumentOutOfRangeException($"{msgnum} value {outputValue} is outside specified bounds");
+
+#if DEBUG
+            _logger.Info($"Retrieved option {msgnum} value: {outputValue}");
+#endif
+
+            Registers.AX = outputValue;
         }
 
     }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -31,7 +31,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private IntPtr16 _currentMcvFile
         {
             get => Module.Memory.GetPointer("CURRENT-MCV");
-            set => Module.Memory.SetPointer("CURRENT-MCV", value);
+            set => Module.Memory.SetPointer("CURRENT-MCV", value ?? IntPtr16.Empty);
         }
         private readonly Stack<IntPtr16> _previousMcvFile;
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -1137,6 +1137,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     break;
                 case 339:
                     hexopt();
+                    break;
                 case 449:
                     onsys();
                     break;

--- a/MBBSEmu/Module/MBBSModule.cs
+++ b/MBBSEmu/Module/MBBSModule.cs
@@ -247,7 +247,7 @@ namespace MBBSEmu.Module
             if (!ExecutionUnits.TryDequeue(out var executionUnit))
             {
                 _logger.Warn($"{ModuleIdentifier} exhausted execution Units, creating additional");
-                executionUnit = new ExecutionUnit(Memory, ExportedModuleDictionary);
+                executionUnit = new ExecutionUnit(Memory, ExportedModuleDictionary, _logger);
             }
 
             var resultRegisters = executionUnit.Execute(entryPoint, channelNumber, simulateCallFar, bypassSetState, initialStackValues, initialStackPointer);

--- a/MBBSEmu/Module/McvFile.cs
+++ b/MBBSEmu/Module/McvFile.cs
@@ -4,6 +4,7 @@ using MBBSEmu.Logging;
 using NLog;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -19,7 +20,7 @@ namespace MBBSEmu.Module
         public readonly string FileName;
         public readonly byte[] FileContent;
         public readonly Dictionary<int, byte[]> Messages;
-        private bool _dynamicLength = false;
+        private bool _dynamicLength;
 
         public McvFile(IFileUtility fileUtility, string fileName, string path = "")
         {
@@ -42,6 +43,17 @@ namespace MBBSEmu.Module
             _logger.Info($"Parsing MCV File: {FileName}");
 #endif
             Parse();
+        }
+
+        /// <summary>
+        ///     Constructor Used for Testing, where the keys are manually passed in
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="messages"></param>
+        public McvFile(string fileName, Dictionary<int, byte[]> messages)
+        {
+            FileName = fileName;
+            Messages = messages;
         }
 
         /// <summary>
@@ -134,6 +146,13 @@ namespace MBBSEmu.Module
         public int GetLong(int ordinal)
         {
             return int.Parse(GetNumericMessageValue(ordinal).ToCharSpan());
+        }
+
+        public ushort GetHex(int ordinal)
+        {
+            var hexValue = Encoding.ASCII.GetString(GetMessageValue(ordinal));
+
+            return ushort.Parse(hexValue, NumberStyles.HexNumber);
         }
 
         /// <summary>


### PR DESCRIPTION
- Added MAJORBBS.339 (hexopt)
- Added ability to Unit Test MCV Files
- Changed _currentMcvFile to read a pointer from Memory so it can be set externally without modifying encapsulation

Fixes #101 