### PR TITLE
Fixes for ENTER and SPRINTF()

### DIFF
--- a/MBBSEmu.Tests/CPU/ENTER_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ENTER_Tests.cs
@@ -1,0 +1,27 @@
+﻿using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class ENTER_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(0)]
+        [InlineData(0x10)]
+        [InlineData(0xFF)]
+        public void ENTER_Test(ushort frameSize)
+        {
+            Reset();
+
+            mbbsEmuMemoryCore.AddSegment(0); //ENTER relies on the stack
+
+            var instructions = new Assembler(16);
+            instructions.enter(frameSize, 0);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(mbbsEmuCpuCore.Registers.BP - frameSize, mbbsEmuCpuCore.Registers.SP);
+        }
+    }
+}

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -252,7 +252,6 @@ namespace MBBSEmu.CPU
 
             //Show Debugging
             //_showDebug = Registers.CS == 0x3 && Registers.IP >= 0x4947 && Registers.IP <= 0x777E;
-
             //_showDebug = (Registers.CS == 0x6 && Registers.IP >= 0x352A && Registers.IP <= 0x3562);
 
             if (_showDebug)
@@ -811,7 +810,7 @@ namespace MBBSEmu.CPU
                         return;
                     }
                 default:
-                    throw new ArgumentOutOfRangeException($"Uknown Destination: {_currentInstruction.Op0Kind}");
+                    throw new ArgumentOutOfRangeException($"Unknown Destination: {_currentInstruction.Op0Kind}");
             }
         }
 
@@ -863,7 +862,7 @@ namespace MBBSEmu.CPU
                         return;
                     }
                 default:
-                    throw new ArgumentOutOfRangeException($"Uknown Source: {_currentInstruction.Op0Kind}");
+                    throw new ArgumentOutOfRangeException($"Unknown Source: {_currentInstruction.Op0Kind}");
             }
         }
 
@@ -892,7 +891,7 @@ namespace MBBSEmu.CPU
                     Op_Int_21h();
                     return;
                 default:
-                    throw new ArgumentOutOfRangeException($"Uknown INT: {_currentInstruction.Immediate8:X2}");
+                    throw new ArgumentOutOfRangeException($"Unknown INT: {_currentInstruction.Immediate8:X2}");
             }
         }
 
@@ -1486,10 +1485,10 @@ namespace MBBSEmu.CPU
                 case OpKind.Immediate16:
                     Push(Registers.BP);
                     Registers.BP = Registers.SP;
-                    Registers.SP -= (ushort)(_currentInstruction.Immediate16 + 1);
+                    Registers.SP -= _currentInstruction.Immediate16;
                     break;
                 default:
-                    throw new ArgumentOutOfRangeException($"Uknown ENTER: {_currentInstruction.Op0Kind}");
+                    throw new ArgumentOutOfRangeException($"Unknown ENTER: {_currentInstruction.Op0Kind}");
             }
         }
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3094,17 +3094,15 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void sprintf()
         {
-            var destinationOffset = GetParameter(0);
-            var destinationSegment = GetParameter(1);
-            var sourceOffset = GetParameter(2);
-            var sourceSegment = GetParameter(3);
+            var destination = GetParameterPointer(0);
+            var source = GetParameterPointer(2);
 
-            var output = Module.Memory.GetString(sourceSegment, sourceOffset);
+            var output = Module.Memory.GetString(source);
 
             //If the supplied string has any control characters for formatting, process them
             var formattedMessage = FormatPrintf(output, 4);
 
-            Module.Memory.SetArray(destinationSegment, destinationOffset, formattedMessage);
+            Module.Memory.SetArray(destination, formattedMessage);
 
 #if DEBUG
             _logger.Info($"Added {output.Length} bytes to the buffer: {Encoding.ASCII.GetString(formattedMessage)}");


### PR DESCRIPTION
- Fixed `ENTER` x86 Opcode (not adding +1)
- Fixed Typos in CPU Core
- Changed `sprintf()` to use ParameterPointers

Fixes #150 