### PR TITLE
Enhance x87 Floating Point Operations to Support Double (64bit) Floats

### DIFF
--- a/MBBSEmu.Tests/CPU/FADDP_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FADDP_Tests.cs
@@ -14,7 +14,34 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(float.NaN, 1)]
         [InlineData(-2.5, 3.5)]
         [InlineData(-2.5, -1.0)]
-        public void FADDP_Test(float ST0Value, float ST1Value)
+        public void FADDP_Test_Float(float ST0Value, float ST1Value)
+        {
+            Reset();
+
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(1);
+            mbbsEmuCpuCore.FpuStack[1] = ST0Value; //ST0
+            mbbsEmuCpuCore.FpuStack[0] = ST1Value; //ST1
+
+            var instructions = new Assembler(16);
+            instructions.faddp(st1, st0);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            var expectedValue = ST0Value + ST1Value;
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(0.5, 1.5)]
+        [InlineData(double.MaxValue, 1)]
+        [InlineData(double.MinValue, double.MaxValue)]
+        [InlineData(0, 0)]
+        [InlineData(double.NaN, 1)]
+        [InlineData(-2.5, 3.5)]
+        [InlineData(-2.5, -1.0)]
+        public void FADDP_Test_Double(double ST0Value, double ST1Value)
         {
             Reset();
 

--- a/MBBSEmu.Tests/CPU/FADD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FADD_Tests.cs
@@ -12,7 +12,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(float.MaxValue, 1)]
         [InlineData(float.MinValue, float.MaxValue)]
         [InlineData(0, 0)]
-        public void FADD_Test(float initialST0Value, float valueToAdd)
+        public void FADD_Test_M32(float initialST0Value, float valueToAdd)
         {
             Reset();
 
@@ -24,6 +24,32 @@ namespace MBBSEmu.Tests.CPU
 
             var instructions = new Assembler(16);
             instructions.fadd(__dword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            var expectedValue = initialST0Value + valueToAdd;
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(0.5, 1.5)]
+        [InlineData(double.MaxValue, 1)]
+        [InlineData(double.MinValue, double.MaxValue)]
+        [InlineData(0, 0)]
+        public void FADD_Test_M64(double initialST0Value, double valueToAdd)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(valueToAdd));
+            mbbsEmuCpuRegisters.DS = 2;
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = initialST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fadd(__qword_ptr[0]);
             CreateCodeSegment(instructions);
 
             mbbsEmuCpuCore.Tick();

--- a/MBBSEmu.Tests/CPU/FDIV_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FDIV_Tests.cs
@@ -11,7 +11,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(2, 2)]
         [InlineData(1, .5)]
         [InlineData(0, 0)]
-        public void FDIV_Test(float initialST0Value, float valueToDivide)
+        public void FDIV_Test_M32(float initialST0Value, float valueToDivide)
         {
             Reset();
 
@@ -23,6 +23,31 @@ namespace MBBSEmu.Tests.CPU
 
             var instructions = new Assembler(16);
             instructions.fdiv(__dword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            var expectedValue = initialST0Value / valueToDivide;
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(2, 2)]
+        [InlineData(1, .5)]
+        [InlineData(0, 0)]
+        public void FDIV_Test_M64(double initialST0Value, double valueToDivide)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(valueToDivide));
+            mbbsEmuCpuRegisters.DS = 2;
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = initialST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fdiv(__qword_ptr[0]);
             CreateCodeSegment(instructions);
 
             mbbsEmuCpuCore.Tick();

--- a/MBBSEmu.Tests/CPU/FILD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FILD_Tests.cs
@@ -11,7 +11,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0)]
         [InlineData(ushort.MaxValue)]
         [InlineData(ushort.MinValue)]
-        public void FILD_Test(ushort valueToLoad)
+        public void FILD_Test_M16(ushort valueToLoad)
         {
             Reset();
 
@@ -31,7 +31,7 @@ namespace MBBSEmu.Tests.CPU
         [Theory]
         [InlineData(1, 2)]
         [InlineData(ushort.MaxValue, ushort.MinValue)]
-        public void FILD_Multiple_Test(ushort st0, ushort st1)
+        public void FILD_Multiple_Test_M16(ushort st0, ushort st1)
         {
             Reset();
 
@@ -43,6 +43,96 @@ namespace MBBSEmu.Tests.CPU
             var instructions = new Assembler(16);
             instructions.fild(__word_ptr[0]);
             instructions.fild(__word_ptr[2]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(st0, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(st1, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(uint.MaxValue)]
+        [InlineData(uint.MinValue)]
+        public void FILD_Test_M32(uint valueToLoad)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(valueToLoad));
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fild(__dword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(valueToLoad, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(1, 2)]
+        [InlineData(uint.MaxValue, uint.MinValue)]
+        public void FILD_Multiple_Test_M32(uint st0, uint st1)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(st1)); //ST(0)
+            mbbsEmuMemoryCore.SetArray(2, 4, BitConverter.GetBytes(st0)); //ST(0)->ST(1), new ST(0)
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fild(__dword_ptr[0]);
+            instructions.fild(__dword_ptr[4]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(st0, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(st1, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(ulong.MaxValue)]
+        [InlineData(ulong.MinValue)]
+        public void FILD_Test_M64(ulong valueToLoad)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(valueToLoad));
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fild(__qword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(valueToLoad, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(1, 2)]
+        [InlineData(ulong.MaxValue, ulong.MinValue)]
+        public void FILD_Multiple_Test_M64(ulong st0, ulong st1)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(st1)); //ST(0)
+            mbbsEmuMemoryCore.SetArray(2, 8, BitConverter.GetBytes(st0)); //ST(0)->ST(1), new ST(0)
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fild(__qword_ptr[0]);
+            instructions.fild(__qword_ptr[8]);
             CreateCodeSegment(instructions);
 
             mbbsEmuCpuCore.Tick();

--- a/MBBSEmu.Tests/CPU/FLD_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FLD_Tests.cs
@@ -11,7 +11,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0.0f)]
         [InlineData(float.MaxValue)]
         [InlineData(float.MinValue)]
-        public void FLD_Test(float valueToLoad)
+        public void FLD_Test_M32(float valueToLoad)
         {
             Reset();
 
@@ -31,7 +31,7 @@ namespace MBBSEmu.Tests.CPU
         [Theory]
         [InlineData(1, 2)]
         [InlineData(float.MaxValue, float.MinValue)]
-        public void FLD_Multiple_Test(float st0, float st1)
+        public void FLD_Multiple_Test_M32(float st0, float st1)
         {
             Reset();
 
@@ -43,6 +43,51 @@ namespace MBBSEmu.Tests.CPU
             var instructions = new Assembler(16);
             instructions.fld(__dword_ptr[0]);
             instructions.fld(__dword_ptr[4]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(st0, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+            Assert.Equal(st1, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackPointer(Register.ST1)]);
+        }
+
+        [Theory]
+        [InlineData(0.0f)]
+        [InlineData(double.MaxValue)]
+        [InlineData(double.MinValue)]
+        public void FLD_Test_M64(double valueToLoad)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(valueToLoad));
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fld(__qword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(valueToLoad, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(1, 2)]
+        [InlineData(double.MaxValue, double.MinValue)]
+        public void FLD_Multiple_Test_M64(double st0, double st1)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(st1)); //ST(0)
+            mbbsEmuMemoryCore.SetArray(2, 8, BitConverter.GetBytes(st0)); //ST(0)->ST(1), new ST(0)
+            mbbsEmuCpuRegisters.DS = 2;
+
+            var instructions = new Assembler(16);
+            instructions.fld(__qword_ptr[0]);
+            instructions.fld(__qword_ptr[8]);
             CreateCodeSegment(instructions);
 
             mbbsEmuCpuCore.Tick();

--- a/MBBSEmu.Tests/CPU/FMUL_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FMUL_Tests.cs
@@ -12,7 +12,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(1, 0)]
         [InlineData(10, 2.5)]
         [InlineData(0, 0)]
-        public void FMUL_Test(float initialST0Value, float valueToMultiply)
+        public void FMUL_Test_M32(float initialST0Value, float valueToMultiply)
         {
             Reset();
 
@@ -24,6 +24,32 @@ namespace MBBSEmu.Tests.CPU
 
             var instructions = new Assembler(16);
             instructions.fmul(__dword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            var expectedValue = initialST0Value * valueToMultiply;
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+
+        [Theory]
+        [InlineData(2d, .5d)]
+        [InlineData(1d, 0d)]
+        [InlineData(10d, 2.5d)]
+        [InlineData(0d, 0d)]
+        public void FMUL_Test_M64(double initialST0Value, double valueToMultiply)
+        {
+            Reset();
+
+            CreateDataSegment(new ReadOnlySpan<byte>(), 2);
+            mbbsEmuMemoryCore.SetArray(2, 0, BitConverter.GetBytes(valueToMultiply));
+            mbbsEmuCpuRegisters.DS = 2;
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[0] = initialST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.fmul(__qword_ptr[0]);
             CreateCodeSegment(instructions);
 
             mbbsEmuCpuCore.Tick();

--- a/MBBSEmu.Tests/CPU/FSUBR_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FSUBR_Tests.cs
@@ -37,6 +37,39 @@ namespace MBBSEmu.Tests.CPU
             var result = mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()];
             var expectedResult = value2 - value1;
 
+            Assert.Equal(expectedResult, (float)result);
+        }
+
+        [Theory]
+        [InlineData(1d, .5d)]
+        [InlineData(10d, 5d)]
+        [InlineData(10.1d, .1d)]
+        [InlineData(1.5d, 2.0d)]
+        [InlineData(0d, 0d)]
+        public void FSUBR_Test_M64(double value1, double value2)
+        {
+            //Reset the CPU
+            Reset();
+
+            //Load Value1 into the x87 Stack
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()] = value1;
+
+            //Load Value2 into Memory & Setup DS
+            CreateDataSegment(BitConverter.GetBytes(value2));
+            mbbsEmuCpuRegisters.DS = 2;
+
+            //Setup CPU & CODE Segment
+            var instructions = new Assembler(16);
+            instructions.fsubr(__qword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            var result = mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()];
+            var expectedResult = value2 - value1;
+
             Assert.Equal(expectedResult, result);
         }
     }

--- a/MBBSEmu.Tests/CPU/FSUB_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FSUB_Tests.cs
@@ -34,6 +34,36 @@ namespace MBBSEmu.Tests.CPU
 
             var result = mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()];
 
+            Assert.Equal(expectedResult, (float)result);
+        }
+
+        [Theory]
+        [InlineData(1d, .5d, .5d)]
+        [InlineData(10d, 5d, 5d)]
+        [InlineData(10.1d, .1d, 10d)]
+        public void FSUB_Test_M64(double value1, double value2, double expectedResult)
+        {
+            //Reset the CPU
+            Reset();
+
+            //Load Value1 into the x87 Stack
+            mbbsEmuCpuRegisters.Fpu.SetStackTop(0);
+            mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()] = value1;
+
+            //Load Value2 into Memory & Setup DS
+            CreateDataSegment(BitConverter.GetBytes(value2));
+            mbbsEmuCpuRegisters.DS = 2;
+
+            //Setup CPU & CODE Segment
+            var instructions = new Assembler(16);
+            instructions.fsub(__qword_ptr[0]);
+            CreateCodeSegment(instructions);
+
+            //Process Instruction
+            mbbsEmuCpuCore.Tick();
+
+            var result = mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()];
+
             Assert.Equal(expectedResult, result);
         }
     }

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -88,7 +88,7 @@ namespace MBBSEmu.CPU
         ///
         ///     The x87 Stack contains eight slots for 32-bit (Single Precision) Floating Point values
         /// </summary>
-        public readonly float[] FpuStack = new float[8];
+        public readonly double[] FpuStack = new double[8];
 
         /// <summary>
         ///     Size of the current operation (in bytes)
@@ -248,7 +248,7 @@ namespace MBBSEmu.CPU
 
             //Breakpoint
             //if (Registers.CS == 0x2 && Registers.IP == 0x3352)
-                //Debugger.Break();
+            //Debugger.Break();
 
             //Show Debugging
             //_showDebug = Registers.CS == 0x3 && Registers.IP >= 0x4947 && Registers.IP <= 0x777E;
@@ -532,8 +532,9 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
-        ///     Returns the VALUE of Operand 0
-        ///     Only use this for instructions where Operand 0 is a VALUE, not an address target
+        ///     Returns the Operand Value as a 8-bit Integer
+        ///
+        ///     Operand Sizes Equal to or Less than 8-Bit are Supported and returned as a 8-bit Integer
         /// </summary>
         /// <param name="opKind"></param>
         /// <param name="operandType"></param>
@@ -563,23 +564,23 @@ namespace MBBSEmu.CPU
 
                         switch (_currentInstruction.MemorySize)
                         {
-                            //gets byte at the specified memory location
+                            case MemorySize.Int8:
                             case MemorySize.UInt8:
                                 return Memory.GetByte(Registers.GetValue(_currentInstruction.MemorySegment), offset);
                             default:
-                                throw new Exception("Type Requested not UInt8");
+                                throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}");
                         }
-
                     }
 
                 default:
-                    throw new ArgumentOutOfRangeException($"Unknown UInt8 Operand: {opKind}");
+                    throw new Exception($"Unsupported OpKind: {opKind}");
             }
         }
 
         /// <summary>
-        ///     Returns the VALUE of Operand 0
-        ///     Only use this for instructions where Operand 0 is a VALUE, not an address target
+        ///     Returns the Operand Value as a 16-bit Integer
+        ///
+        ///     Operand Sizes Equal to or Less than 16-Bit are Supported and returned as a 16-bit Integer
         /// </summary>
         /// <param name="opKind"></param>
         /// <param name="operandType"></param>
@@ -609,61 +610,127 @@ namespace MBBSEmu.CPU
                     return (ushort)_currentInstruction.Immediate8to16;
                 case OpKind.Memory:
                     {
-                        //Relocation Record is applied to the offset of the value
-                        //Because of this, we return out
                         var offset = GetOperandOffset(opKind);
 
                         switch (_currentInstruction.MemorySize)
                         {
+                            case MemorySize.Int8:
+                            case MemorySize.UInt8:
+                                return Memory.GetByte(Registers.GetValue(_currentInstruction.MemorySegment), offset);
                             case MemorySize.Int16:
                             case MemorySize.UInt16:
                                 return Memory.GetWord(Registers.GetValue(_currentInstruction.MemorySegment), offset);
                             default:
-                                throw new Exception("Type Requested not UInt16");
+                                throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}");
                         }
-
                     }
 
                 default:
-                    throw new ArgumentOutOfRangeException($"Unknown UInt16 Operand: {opKind}");
+                    throw new Exception($"Unsupported OpKind: {opKind}");
             }
         }
 
         /// <summary>
-        ///     Returns the VALUE of Operand 0
-        ///     Only use this for instructions where Operand 0 is a VALUE, not an address target
+        ///     Returns the Operand Value as a 32-bit Integer
+        ///
+        ///     Operand Sizes Equal to or Less than 32-Bit are Supported and returned as a 32-bit Integer
         /// </summary>
         /// <param name="opKind"></param>
-        /// <param name="operandType"></param>
         /// <returns></returns>
         [MethodImpl(CompilerOptimizations)]
-        private uint GetOperandValueUInt32(OpKind opKind, EnumOperandType operandType)
+        private uint GetOperandValueUInt32(OpKind opKind)
         {
             switch (opKind)
             {
-                case OpKind.Immediate8to32:
-                    return (ushort)_currentInstruction.Immediate8to32;
+                case OpKind.Immediate8:
+                    return _currentInstruction.Immediate8;
+                case OpKind.Immediate16:
+                    return _currentInstruction.Immediate16;
+                case OpKind.Immediate8to16:
+                    return (ushort)_currentInstruction.Immediate8to16;
                 case OpKind.Immediate32:
                     return _currentInstruction.Immediate32;
+                case OpKind.Immediate8to32:
+                    return (uint)_currentInstruction.Immediate8to32;
                 case OpKind.Memory:
                     {
-                        //Relocation Record is applied to the offset of the value
-                        //Because of this, we return out
                         var offset = GetOperandOffset(opKind);
 
                         switch (_currentInstruction.MemorySize)
                         {
+                            case MemorySize.Int8:
+                            case MemorySize.UInt8:
+                                return Memory.GetByte(Registers.GetValue(_currentInstruction.MemorySegment), offset);
+                            case MemorySize.Int16:
+                            case MemorySize.UInt16:
+                                return Memory.GetWord(Registers.GetValue(_currentInstruction.MemorySegment), offset);
+                            case MemorySize.Int32:
                             case MemorySize.UInt32:
                                 return BitConverter.ToUInt32(
                                     Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), offset, 4));
                             default:
-                                throw new Exception("Type Requested not UInt32");
+                                throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}");
                         }
-
                     }
 
                 default:
-                    throw new Exception("Type Requested not UInt32");
+                    throw new Exception($"Unsupported OpKind: {opKind}");
+            }
+        }
+
+        /// <summary>
+        ///     Returns the Operand Value as a 64-bit Integer
+        ///
+        ///     Operand Sizes Equal to or Less than 64-Bit are Supported and returned as a 64-bit Integer
+        /// </summary>
+        /// <param name="opKind"></param>
+        /// <returns></returns>
+        [MethodImpl(CompilerOptimizations)]
+        private ulong GetOperandValueUInt64(OpKind opKind)
+        {
+            switch (opKind)
+            {
+                case OpKind.Immediate8:
+                    return _currentInstruction.Immediate8;
+                case OpKind.Immediate16:
+                    return _currentInstruction.Immediate16;
+                case OpKind.Immediate8to16:
+                    return (ushort)_currentInstruction.Immediate8to16;
+                case OpKind.Immediate32:
+                    return _currentInstruction.Immediate32;
+                case OpKind.Immediate8to32:
+                    return (uint)_currentInstruction.Immediate8to32;
+                case OpKind.Immediate64:
+                    return _currentInstruction.Immediate64;
+                case OpKind.Immediate8to64:
+                    return (ulong)_currentInstruction.Immediate8to64;
+                case OpKind.Memory:
+                    {
+                        var offset = GetOperandOffset(opKind);
+
+                        switch (_currentInstruction.MemorySize)
+                        {
+                            case MemorySize.Int8:
+                            case MemorySize.UInt8:
+                                return Memory.GetByte(Registers.GetValue(_currentInstruction.MemorySegment), offset);
+                            case MemorySize.Int16:
+                            case MemorySize.UInt16:
+                                return Memory.GetWord(Registers.GetValue(_currentInstruction.MemorySegment), offset);
+                            case MemorySize.Int32:
+                            case MemorySize.UInt32:
+                                return BitConverter.ToUInt32(
+                                    Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), offset, 4));
+                            case MemorySize.Int64:
+                            case MemorySize.UInt64:
+                                return BitConverter.ToUInt64(
+                                    Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), offset, 8));
+                            default:
+                                throw new Exception($"Invalid Operand Size: {_currentInstruction.MemorySize}");
+                        }
+                    }
+
+                default:
+                    throw new Exception($"Unsupported OpKind: {opKind}");
             }
         }
 
@@ -676,21 +743,44 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private float GetOperandValueFloat(OpKind opKind, EnumOperandType operandType)
         {
-            switch (opKind)
+            return opKind switch
             {
-                case OpKind.Memory:
-                {
-                        return BitConverter.ToSingle(Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment),
-                            GetOperandOffset(opKind), 4));
-                }
-                case OpKind.Register when operandType == EnumOperandType.Destination:
-                    return FpuStack[Registers.Fpu.GetStackPointer(_currentInstruction.Op0Register)];
-                case OpKind.Register when operandType == EnumOperandType.Source:
-                    return FpuStack[Registers.Fpu.GetStackPointer(_currentInstruction.Op1Register)];
-                default:
-                    throw new Exception($"Unknown Float Operand: {opKind}");
-            }
+                OpKind.Memory => BitConverter.ToSingle(
+                    Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(opKind),
+                        4)),
+                OpKind.Register when operandType == EnumOperandType.Destination => (float) FpuStack[
+                    Registers.Fpu.GetStackPointer(_currentInstruction.Op0Register)],
+                OpKind.Register when operandType == EnumOperandType.Source => (float) FpuStack[
+                    Registers.Fpu.GetStackPointer(_currentInstruction.Op1Register)],
+                _ => throw new Exception($"Unknown Float Operand: {opKind}")
+            };
+        }
 
+        /// <summary>
+        ///     Returns the Operand Value as a 64-bit Double
+        ///
+        ///     Operand Sizes Equal to or Less than 64-Bit are Supported and returned as a 64-bit Double
+        /// </summary>
+        /// <param name="opKind"></param>
+        /// <param name="operandType"></param>
+        /// <returns></returns>
+        [MethodImpl(CompilerOptimizations)]
+        private double GetOperandValueDouble(OpKind opKind, EnumOperandType operandType)
+        {
+            return opKind switch
+            {
+                OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float32 => BitConverter.ToSingle(
+                    Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(opKind),
+                        4)),
+                OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float64 => BitConverter.ToDouble(
+                    Memory.GetArray(Registers.GetValue(_currentInstruction.MemorySegment), GetOperandOffset(opKind),
+                        8)),
+                OpKind.Register when operandType == EnumOperandType.Destination => FpuStack[
+                    Registers.Fpu.GetStackPointer(_currentInstruction.Op0Register)],
+                OpKind.Register when operandType == EnumOperandType.Source => FpuStack[
+                    Registers.Fpu.GetStackPointer(_currentInstruction.Op1Register)],
+                _ => throw new Exception($"Unknown Double Operand: {opKind}")
+            };
         }
 
         /// <summary>
@@ -834,6 +924,29 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
+        ///     Writes the specified result of the instruction into the specified destination
+        /// </summary>
+        /// <param name="result"></param>
+        [MethodImpl(CompilerOptimizations)]
+        private void WriteToDestination(double result)
+        {
+            switch (_currentInstruction.Op0Kind)
+            {
+                case OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float32:
+                    Memory.SetArray(Registers.GetValue(_currentInstruction.MemorySegment),
+                        GetOperandOffset(_currentInstruction.Op0Kind), BitConverter.GetBytes((float)result));
+                    break;
+                case OpKind.Memory when _currentInstruction.MemorySize == MemorySize.Float64:
+                    Memory.SetArray(Registers.GetValue(_currentInstruction.MemorySegment),
+                        GetOperandOffset(_currentInstruction.Op0Kind), BitConverter.GetBytes(result));
+                    break;
+                case OpKind.Register:
+                    FpuStack[Registers.Fpu.GetStackPointer(_currentInstruction.Op0Register)] = result;
+                    break;
+            }
+        }
+
+        /// <summary>
         ///     Saves the specified result of the current instruction into the current instructions source
         ///
         ///     This is only used by a couple specific opcodes
@@ -957,18 +1070,18 @@ namespace MBBSEmu.CPU
                         return;
                     }
                 case 0x62:
-                {
+                    {
                         /*
                             INT 21 - AH = 62h DOS 3.x - GET PSP ADDRESS
                             Return: BX = segment address of PSP
                             We allocate 0xFFFF to ensure it has it's own segment in memory
                          */
-                        if(!Memory.TryGetVariablePointer("INT21h-PSP", out var pspPointer))
+                        if (!Memory.TryGetVariablePointer("INT21h-PSP", out var pspPointer))
                             pspPointer = Memory.AllocateVariable("Int21h-PSP", 0xFFFF);
 
                         Registers.BX = pspPointer.Segment;
                         return;
-                }
+                    }
                 default:
                     throw new ArgumentOutOfRangeException($"Unsupported INT 21h Function: 0x{Registers.AH:X2}");
             }
@@ -1989,8 +2102,8 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private uint Op_Sub_32()
         {
-            var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind, EnumOperandType.Destination);
-            var source = GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var destination = GetOperandValueUInt32(_currentInstruction.Op0Kind);
+            var source = GetOperandValueUInt32(_currentInstruction.Op1Kind);
 
             unchecked
             {
@@ -2243,7 +2356,7 @@ namespace MBBSEmu.CPU
                     {
                         Memory.SetArray(Registers.GetValue(_currentInstruction.MemorySegment),
                             GetOperandOffset(_currentInstruction.Op0Kind),
-                            BitConverter.GetBytes(GetOperandValueUInt32(_currentInstruction.Op1Kind, EnumOperandType.Source)));
+                            BitConverter.GetBytes(GetOperandValueUInt32(_currentInstruction.Op1Kind)));
                         return;
                     }
 
@@ -2329,7 +2442,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fld()
         {
-            var floatToLoad = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var floatToLoad = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
 
             //Set Value as new ST(0)
             Registers.Fpu.PushStackTop();
@@ -2342,12 +2455,10 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fild()
         {
-            var intToLoad = GetOperandValueUInt16(_currentInstruction.Op0Kind, EnumOperandType.Source);
-
-            var convertedInt = Convert.ToSingle(intToLoad);
+            var valueToLoad = GetOperandValueUInt64(_currentInstruction.Op0Kind);
 
             Registers.Fpu.PushStackTop();
-            FpuStack[Registers.Fpu.GetStackTop()] = convertedInt;
+            FpuStack[Registers.Fpu.GetStackTop()] = valueToLoad;
 
         }
 
@@ -2358,7 +2469,7 @@ namespace MBBSEmu.CPU
         private void Op_Fmul()
         {
             var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
-            var source = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var source = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
 
             var result = ST0 * source;
             FpuStack[Registers.Fpu.GetStackTop()] = result;
@@ -2562,7 +2673,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fsub()
         {
-            var floatToSubtract = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var floatToSubtract = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
             var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
 
             var result = ST0 - floatToSubtract;
@@ -2575,10 +2686,10 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fsubr()
         {
-            var floatToSubtract = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var valueToSubtractFrom = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
             var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
 
-            var result = floatToSubtract - ST0;
+            var result = valueToSubtractFrom - ST0;
             FpuStack[Registers.Fpu.GetStackTop()] = result;
         }
 
@@ -2589,7 +2700,7 @@ namespace MBBSEmu.CPU
         private void Op_Fldz()
         {
             Registers.Fpu.PushStackTop();
-            FpuStack[Registers.Fpu.GetStackTop()] = 0.0f; //set ST(0) to 0.0
+            FpuStack[Registers.Fpu.GetStackTop()] = 0d; //set ST(0) to 0.0
         }
 
         /// <summary>
@@ -2641,8 +2752,8 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Faddp()
         {
-            var STdestination = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Destination);
-            var STsource = GetOperandValueFloat(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var STdestination = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var STsource = GetOperandValueDouble(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
             var result = STdestination + STsource;
 
@@ -2828,7 +2939,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fdiv()
         {
-            var source = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var source = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
             var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
 
             var result = ST0 / source;
@@ -2841,10 +2952,10 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fmulp()
         {
-            var float1 = FpuStack[Registers.Fpu.GetStackTop()];
-            var float2 = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
+            var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
+            var ST1 = FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)];
 
-            var result = float1 * float2;
+            var result = ST0 * ST1;
 
             //Store result at ST1
             FpuStack[Registers.Fpu.GetStackPointer(Register.ST1)] = result;
@@ -2861,7 +2972,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fcomp()
         {
-            var source = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var source = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
             var ST0 = FpuStack[Registers.Fpu.GetStackTop()];
 
             Registers.Fpu.PopStackTop();
@@ -2905,7 +3016,7 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Fadd()
         {
-            var floatToAdd = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Source);
+            var floatToAdd = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Source);
             var floatOnFpuStack = FpuStack[Registers.Fpu.GetStackTop()];
 
             var result = floatOnFpuStack + floatToAdd;
@@ -2918,8 +3029,8 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_fdivp()
         {
-            var STdestination = GetOperandValueFloat(_currentInstruction.Op0Kind, EnumOperandType.Destination);
-            var STsource = GetOperandValueFloat(_currentInstruction.Op1Kind, EnumOperandType.Source);
+            var STdestination = GetOperandValueDouble(_currentInstruction.Op0Kind, EnumOperandType.Destination);
+            var STsource = GetOperandValueDouble(_currentInstruction.Op1Kind, EnumOperandType.Source);
 
             var result = STdestination / STsource;
 


### PR DESCRIPTION
- Added M64 Operations to x87 Opcodes
- Supports loading 16-bit, 32-bit, and 64-bit Integers into x87 FPU Stack
- Enhanced `GetOperandValueXXX` to return operand values <= the desired size, cast as the desired size

Fixes #152 