### PR TITLE
New x87/x86 Opcodes

### DIFF
--- a/MBBSEmu.Tests/CPU/FCLEX_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FCLEX_Tests.cs
@@ -1,0 +1,24 @@
+﻿using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FCLEX_Tests : CpuTestBase
+    {
+        [Fact]
+        public void FCLEX_Test()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.Fpu.StatusWord = 0x3F; //Set all 6 Error Flags
+
+            var instructions = new Assembler(16);
+            instructions.fclex();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0, mbbsEmuCpuRegisters.Fpu.StatusWord);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
@@ -10,6 +10,8 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(0.1d, 0d)]
         [InlineData(1.9d, 2d)]
         [InlineData(-1.9d, -2d)]
+        [InlineData(0.5d, 1d)]
+        [InlineData(0.49999999d, 0d)]
         public void FRNDINT_Test(double ST0Value, double expectedValue)
         {
             Reset();

--- a/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FRNDINT_Tests.cs
@@ -1,0 +1,27 @@
+﻿using Iced.Intel;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FRNDINT_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(2.1d, 2d)]
+        [InlineData(0.1d, 0d)]
+        [InlineData(1.9d, 2d)]
+        [InlineData(-1.9d, -2d)]
+        public void FRNDINT_Test(double ST0Value, double expectedValue)
+        {
+            Reset();
+            mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.frndint();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedValue, mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()]);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FTST_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FTST_Tests.cs
@@ -1,0 +1,30 @@
+﻿using Iced.Intel;
+using MBBSEmu.CPU;
+using Xunit;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class FTST_Tests : CpuTestBase
+    {
+        [Theory]
+        [InlineData(1.0d, 0)]
+        [InlineData(double.MaxValue, 0)]
+        [InlineData(-1.0d, (ushort)(0 | EnumFpuStatusFlags.Code0))]
+        [InlineData(double.MinValue, (ushort)(0 | EnumFpuStatusFlags.Code0))]
+        [InlineData(0.0d, (ushort)(0 | EnumFpuStatusFlags.Code3))]
+        public void FTST_Test(double ST0Value, ushort expectedFlags)
+        {
+            Reset();
+            mbbsEmuCpuRegisters.Fpu.StatusWord = 0; //Manually Clear all Status Values
+            mbbsEmuCpuCore.FpuStack[mbbsEmuCpuRegisters.Fpu.GetStackTop()] = ST0Value;
+
+            var instructions = new Assembler(16);
+            instructions.ftst();
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(expectedFlags, mbbsEmuCpuRegisters.Fpu.StatusWord);
+        }
+    }
+}

--- a/MBBSEmu.Tests/CPU/FTST_Tests.cs
+++ b/MBBSEmu.Tests/CPU/FTST_Tests.cs
@@ -12,6 +12,7 @@ namespace MBBSEmu.Tests.CPU
         [InlineData(-1.0d, (ushort)(0 | EnumFpuStatusFlags.Code0))]
         [InlineData(double.MinValue, (ushort)(0 | EnumFpuStatusFlags.Code0))]
         [InlineData(0.0d, (ushort)(0 | EnumFpuStatusFlags.Code3))]
+        [InlineData(double.NaN, (ushort)(0 | EnumFpuStatusFlags.Code3 | EnumFpuStatusFlags.Code2 | EnumFpuStatusFlags.Code0))]
         public void FTST_Test(double ST0Value, ushort expectedFlags)
         {
             Reset();

--- a/MBBSEmu.Tests/CPU/ROR_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ROR_Tests.cs
@@ -8,11 +8,10 @@ namespace MBBSEmu.Tests.CPU
     public class ROR_Tests : CpuTestBase
     {
         [Fact]
-        public void ROR_AX_1()
+        public void ROR_AX_IMM16_1()
         {
             Reset();
             mbbsEmuCpuRegisters.AX = 2;
-
 
             var instructions = new Assembler(16);
             instructions.ror(ax, 1);
@@ -24,11 +23,10 @@ namespace MBBSEmu.Tests.CPU
         }
 
         [Fact]
-        public void ROR_AX_CF_OF()
+        public void ROR_AX_IMM16_CF_OF()
         {
             Reset();
             mbbsEmuCpuRegisters.AX = 1;
-
 
             var instructions = new Assembler(16);
             instructions.ror(ax, 1);
@@ -42,11 +40,10 @@ namespace MBBSEmu.Tests.CPU
         }
 
         [Fact]
-        public void ROR_AX_OF()
+        public void ROR_AX_IMM16_OF()
         {
             Reset();
             mbbsEmuCpuRegisters.AX = 0x8000;
-
 
             var instructions = new Assembler(16);
             instructions.ror(ax, 1);
@@ -60,11 +57,10 @@ namespace MBBSEmu.Tests.CPU
         }
 
         [Fact]
-        public void ROR_AL_1()
+        public void ROR_AL_IMM8_1()
         {
             Reset();
             mbbsEmuCpuRegisters.AL = 2;
-
 
             var instructions = new Assembler(16);
             instructions.ror(al, 1);
@@ -76,11 +72,10 @@ namespace MBBSEmu.Tests.CPU
         }
 
         [Fact]
-        public void ROR_AL_CF_OF()
+        public void ROR_AL_IMM8_CF_OF()
         {
             Reset();
             mbbsEmuCpuRegisters.AL = 1;
-
 
             var instructions = new Assembler(16);
             instructions.ror(al, 1);
@@ -94,11 +89,10 @@ namespace MBBSEmu.Tests.CPU
         }
 
         [Fact]
-        public void ROR_AL_OF()
+        public void ROR_AL_IMM8_OF()
         {
             Reset();
             mbbsEmuCpuRegisters.AL = 0x80;
-
 
             var instructions = new Assembler(16);
             instructions.ror(al, 1);
@@ -109,6 +103,71 @@ namespace MBBSEmu.Tests.CPU
             Assert.Equal(0x80 >> 1, mbbsEmuCpuRegisters.AX);
             Assert.False(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.CF));
             Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.OF));
+        }
+
+        [Fact]
+        public void ROR_M8_IMM8_1()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.DS = 2;
+            CreateDataSegment(new byte[] { 2 }, 2);
+
+            var instructions = new Assembler(16);
+            instructions.ror(__byte_ptr[0], 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(2 >> 1, mbbsEmuMemoryCore.GetByte(2,0));
+        }
+
+        [Fact]
+        public void ROR_M16_IMM8_1()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.DS = 2;
+            CreateDataSegment(BitConverter.GetBytes((ushort)2), 2);
+
+            var instructions = new Assembler(16);
+            instructions.ror(__word_ptr[0], 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(2 >> 1, mbbsEmuMemoryCore.GetByte(2, 0));
+        }
+
+        [Fact]
+        public void ROR_M8_CL_1()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.DS = 2;
+            mbbsEmuCpuRegisters.CL = 1;
+            CreateDataSegment(new byte[] { 2 }, 2);
+
+            var instructions = new Assembler(16);
+            instructions.ror(__byte_ptr[0],cl);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(2 >> 1, mbbsEmuMemoryCore.GetByte(2, 0));
+        }
+
+        [Fact]
+        public void ROR_M8_IMM8_7()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.DS = 2;
+            CreateDataSegment(new byte[] { 0x80 }, 2);
+
+            var instructions = new Assembler(16);
+            instructions.ror(__byte_ptr[0], 7);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x80 >> 7, mbbsEmuMemoryCore.GetByte(2, 0));
         }
     }
 }

--- a/MBBSEmu.Tests/CPU/ROR_Tests.cs
+++ b/MBBSEmu.Tests/CPU/ROR_Tests.cs
@@ -1,0 +1,114 @@
+﻿using Iced.Intel;
+using System;
+using Xunit;
+using static Iced.Intel.AssemblerRegisters;
+
+namespace MBBSEmu.Tests.CPU
+{
+    public class ROR_Tests : CpuTestBase
+    {
+        [Fact]
+        public void ROR_AX_1()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = 2;
+
+
+            var instructions = new Assembler(16);
+            instructions.ror(ax, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(2 >> 1, mbbsEmuCpuRegisters.AX);
+        }
+
+        [Fact]
+        public void ROR_AX_CF_OF()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = 1;
+
+
+            var instructions = new Assembler(16);
+            instructions.ror(ax, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x8000, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.CF));
+            Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.OF));
+        }
+
+        [Fact]
+        public void ROR_AX_OF()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AX = 0x8000;
+
+
+            var instructions = new Assembler(16);
+            instructions.ror(ax, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x8000 >> 1, mbbsEmuCpuRegisters.AX);
+            Assert.False(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.CF));
+            Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.OF));
+        }
+
+        [Fact]
+        public void ROR_AL_1()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = 2;
+
+
+            var instructions = new Assembler(16);
+            instructions.ror(al, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(2 >> 1, mbbsEmuCpuRegisters.AL);
+        }
+
+        [Fact]
+        public void ROR_AL_CF_OF()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = 1;
+
+
+            var instructions = new Assembler(16);
+            instructions.ror(al, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x80, mbbsEmuCpuRegisters.AX);
+            Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.CF));
+            Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.OF));
+        }
+
+        [Fact]
+        public void ROR_AL_OF()
+        {
+            Reset();
+            mbbsEmuCpuRegisters.AL = 0x80;
+
+
+            var instructions = new Assembler(16);
+            instructions.ror(al, 1);
+            CreateCodeSegment(instructions);
+
+            mbbsEmuCpuCore.Tick();
+
+            Assert.Equal(0x80 >> 1, mbbsEmuCpuRegisters.AX);
+            Assert.False(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.CF));
+            Assert.True(mbbsEmuCpuRegisters.F.IsFlagSet(MBBSEmu.CPU.EnumFlags.OF));
+        }
+    }
+}

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -3084,7 +3084,6 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Ror()
         {
-
             var result = _currentOperationSize switch
             {
                 1 => Op_Ror_8(),
@@ -3093,9 +3092,7 @@ namespace MBBSEmu.CPU
             };
 
             WriteToDestination(result);
-
         }
-
 
         /// <summary>
         ///     8-bit Rotate Right
@@ -3109,7 +3106,7 @@ namespace MBBSEmu.CPU
 
             unchecked
             {
-                var result = (byte) ((destination >> (sbyte) source) | (destination >> (8 - (sbyte) source)));
+                var result = (byte) ((destination >> (sbyte) source) | (destination << (8 - (sbyte) source)));
 
                 //CF Set if Most Significant Bit set to 1
                 if (result.IsNegative())
@@ -3139,7 +3136,7 @@ namespace MBBSEmu.CPU
 
             unchecked
             {
-                var result = (byte)((destination >> (sbyte)source) | (destination >> (16 - (sbyte)source)));
+                var result = (ushort)((destination >> (sbyte)source) | (destination << (16 - (sbyte)source)));
 
                 //CF Set if Most Significant Bit set to 1
                 if (result.IsNegative())
@@ -3158,24 +3155,20 @@ namespace MBBSEmu.CPU
         }
 
         /// <summary>
-        ///     Floating Point Compare ST(0) against 0.0 (x87)
+        ///     Floating Point Compare ST(0) to 0.0 (x87)
         /// </summary>
         [MethodImpl(CompilerOptimizations)]
         private void Op_Ftst()
         {
             var float1 = FpuStack[Registers.Fpu.GetStackTop()];
-            var float2 = 0.0d;
 
-            Registers.Fpu.PopStackTop();
-            Registers.Fpu.PopStackTop();
-
-            if (float1 > float2)
+            if (float1 > 0.0d)
             {
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code0);
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code2);
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code3);
             }
-            else if (float1 < float2)
+            else if (float1 < 0.0d)
             {
                 Registers.Fpu.SetFlag(EnumFpuStatusFlags.Code0);
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code2);

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -3170,17 +3170,25 @@ namespace MBBSEmu.CPU
         [MethodImpl(CompilerOptimizations)]
         private void Op_Ftst()
         {
-            var float1 = FpuStack[Registers.Fpu.GetStackTop()];
+            var ST0Value = FpuStack[Registers.Fpu.GetStackTop()];
 
             Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code1);
 
-            if (float1 > 0.0d)
+            if(double.IsNaN(ST0Value))
+            {
+                Registers.Fpu.SetFlag(EnumFpuStatusFlags.Code0);
+                Registers.Fpu.SetFlag(EnumFpuStatusFlags.Code2);
+                Registers.Fpu.SetFlag(EnumFpuStatusFlags.Code3);
+                return;
+            }
+
+            if (ST0Value > 0.0d)
             {
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code0);
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code2);
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code3);
             }
-            else if (float1 < 0.0d)
+            else if (ST0Value < 0.0d)
             {
                 Registers.Fpu.SetFlag(EnumFpuStatusFlags.Code0);
                 Registers.Fpu.ClearFlag(EnumFpuStatusFlags.Code2);

--- a/MBBSEmu/CPU/EnumFpuStatusFlags.cs
+++ b/MBBSEmu/CPU/EnumFpuStatusFlags.cs
@@ -8,12 +8,12 @@ namespace MBBSEmu.CPU
     [Flags]
     public enum EnumFpuStatusFlags : ushort
     {
-        InvalidOperation = 1,
-        DenormalizedOperand = 1 << 1,
-        ZeroDivide = 1 << 2,
-        Overflow = 1 << 3,
-        Underflow = 1 << 4,
-        Precision = 1 << 5,
+        InvalidOperationException = 1,
+        DenormalizedOperandException = 1 << 1,
+        ZeroDivideException = 1 << 2,
+        OverflowException = 1 << 3,
+        UnderflowException = 1 << 4,
+        PrecisionException = 1 << 5,
         StackFault = 1 << 6,
         ErrorSummaryStatus = 1 << 7,
         Code0 = 1 << 8,

--- a/MBBSEmu/modules.json
+++ b/MBBSEmu/modules.json
@@ -1,13 +1,8 @@
 {
   "Modules": [
     {
-      "Identifier": "MJWWHL",
-      "Path": "D:\\BBS\\Mbbsemu\\modules\\WEELFAME\\",
-    },
-    {
-      "Identifier": "ELWCHT",
-      "Path": "D:\\BBS\\Mbbsemu\\modules\\elwchtd\\",
-      "MenuOptionKey": "C"
+      "Identifier": "ELWSAFE",
+      "Path": "c:\\dos\\modules\\elwsafe\\"
     }
   ]
 }


### PR DESCRIPTION
- Added `FCLEX`
- Added `FRNDINT`
- Added `ROR`
- Added `FTST`
- Added Support for "Loading" 80-Bit Floats (they're saved from the FPU as 64-bit, so we load 80-bit as 64-bit)
- Added `INT 32h` and `HLT` as NOP commands

Fixes #157 