### PR TITLE
Update Global Formatting / Prompt

### DIFF
--- a/MBBSEmu/HostProcess/GlobalRoutines/UsersOnlineGlobal.cs
+++ b/MBBSEmu/HostProcess/GlobalRoutines/UsersOnlineGlobal.cs
@@ -3,7 +3,6 @@ using MBBSEmu.Memory;
 using MBBSEmu.Module;
 using MBBSEmu.Session;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using MBBSEmu.Session.Enums;
 
@@ -76,8 +75,7 @@ namespace MBBSEmu.HostProcess.GlobalRoutines
                             break;
 
                     }
-
-                    sessions[channelNumber].SendToClient($"|YELLOW||B| {s.Channel:D2}   {userName}                          ... {userOptionSelected}|RESET|\r\n".EncodeToANSIArray());
+                    sessions[channelNumber].SendToClient($"|YELLOW||B| {s.Channel:D2}   {userName.PadRight(31, ' ')}... {userOptionSelected}|RESET|\r\n".EncodeToANSIArray());
                 }
 
                 return true;

--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -295,8 +295,7 @@ namespace MBBSEmu.HostProcess.HostRoutines
                 foreach (var m in modules)
                 {
                     EchoToClient(session,
-                        $"   |CYAN||B|{m.Value.MenuOptionKey}|YELLOW| ... {m.Value.ModuleDescription}\r\n".PadRight(3, ' ')
-                            .EncodeToANSIArray());
+                        $"   |CYAN||B|{m.Value.MenuOptionKey.PadRight(modules.Count > 9 ? 2 : 1, ' ')}|YELLOW| ... {m.Value.ModuleDescription}\r\n".EncodeToANSIArray());
                 }
             }
             else

--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -72,6 +72,9 @@ namespace MBBSEmu.HostProcess.HostRoutines
                 case EnumSessionState.MainMenuDisplay:
                     MainMenuDisplay(session, modules);
                     break;
+                case EnumSessionState.MainMenuInputDisplay:
+                    MainMenuInputDisplay(session);
+                    break;
                 case EnumSessionState.MainMenuInput:
                     MainMenuInput(session, modules);
                     ProcessCharacter(session);
@@ -303,11 +306,17 @@ namespace MBBSEmu.HostProcess.HostRoutines
                 EchoToClient(session, File.ReadAllBytes(ansiMenuFileName).ToArray());
             }
 
-            EchoToClient(session, "\r\n|YELLOW||B|Main Menu\r\n".EncodeToANSIArray());
-            EchoToClient(session, "|CYAN||B|Make your selection (X to exit): ".EncodeToANSIArray());
-            session.SessionState = EnumSessionState.MainMenuInput;
+            session.SessionState = EnumSessionState.MainMenuInputDisplay;
         }
 
+        private void MainMenuInputDisplay(SessionBase session)
+        {
+            EchoToClient(session, "\r\n|YELLOW||B|Main Menu\r\n".EncodeToANSIArray());
+            EchoToClient(session, "|CYAN||B|Make your selection (X to exit): ".EncodeToANSIArray());
+            
+            session.SessionState = EnumSessionState.MainMenuInput;
+        }
+        
         private void MainMenuInput(SessionBase session, Dictionary<string, MbbsModule> modules)
         {
             if (session.Status != 3) return;

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -217,10 +217,13 @@ namespace MBBSEmu.HostProcess
                         {
                             session.Status = 1;
                             session.InputBuffer.SetLength(0);
+
+                            //Redisplay Main Menu prompt after global if session is at Main Menu
+                            if (session.SessionState == EnumSessionState.MainMenuInput)
+                            { 
+                                session.SessionState = EnumSessionState.MainMenuInputDisplay;   
+                            }
                             
-                            //Redisplay Main Menu prompt after global
-                            session.SendToClient("\r\n|YELLOW||B|Main Menu\r\n".EncodeToANSIArray());
-                            session.SendToClient("|CYAN||B|Make your selection (X to exit): ".EncodeToANSIArray());
                             continue;
                         }
 

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -217,6 +217,10 @@ namespace MBBSEmu.HostProcess
                         {
                             session.Status = 1;
                             session.InputBuffer.SetLength(0);
+                            
+                            //Redisplay Main Menu prompt after global
+                            session.SendToClient("\r\n|YELLOW||B|Main Menu\r\n".EncodeToANSIArray());
+                            session.SendToClient("|CYAN||B|Make your selection (X to exit): ".EncodeToANSIArray());
                             continue;
                         }
 

--- a/MBBSEmu/Session/Enums/EnumSessionState.cs
+++ b/MBBSEmu/Session/Enums/EnumSessionState.cs
@@ -41,7 +41,8 @@ namespace MBBSEmu.Session.Enums
         /// </summary>
         [DoGlobals]
         MainMenuDisplay,
-
+        MainMenuInputDisplay,
+        
         [DoGlobals]
         MainMenuInput,
 


### PR DESCRIPTION
*Added padding to align user list for /# global
*Corrected padding on menu to account for # of modules and actually format correctly
*Redisplay prompt after global is executed to behave more like MBBS