### PR TITLE
Update MenuRoutines.cs fix sorting >9 modules

### DIFF
--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -295,7 +295,7 @@ namespace MBBSEmu.HostProcess.HostRoutines
                 EchoToClient(session,
                     "\r\n|GREEN||B|Please select one of the following:|RESET|\r\n\r\n".EncodeToANSIArray());
 
-                foreach (var m in modules.Values.OrderBy(x => x.MenuOptionKey))
+                foreach (var m in modules.Values.OrderBy(x => x.MenuOptionKey.PadLeft(4, '0')))
                 {
                     EchoToClient(session,
                         $"   |CYAN||B|{m.MenuOptionKey.PadRight(modules.Count > 9 ? 2 : 1, ' ')}|YELLOW| ... {m.ModuleDescription}\r\n".EncodeToANSIArray());


### PR DESCRIPTION
One last tweak to fix numbers being sorted as strings -- padding 0's to get numbers in correct order.

Modules with custom MenuOptionKeys are sorted as their ascii values but figured if someone is using that they can customize all of them

![Screenshot 2020-10-13 001708](https://user-images.githubusercontent.com/27604078/95818434-7b458900-0ce9-11eb-80ea-e2b11ffdcf29.jpg)
