### PR TITLE
Fixed Parameterized Precision

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -350,6 +350,22 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     if (!string.IsNullOrEmpty(stringPrecisionValue))
                         stringPrecision = int.Parse(stringPrecisionValue);
 
+                    if (stringPrecision == -1)
+                    {
+
+                        if (!isVsPrintf)
+                        {
+                            //printf
+                            stringPrecision = GetParameter(currentParameter++);
+                        }
+                        else
+                        {
+                            //vsprintf
+                            stringPrecision = Module.Memory.GetWord(vsPrintfBase.Segment, vsPrintfBase.Offset);
+                            vsPrintfBase.Offset += 2;
+                        }
+                    }
+
                     //Process Length
                     //TODO -- We'll process it but ignore it for now
                     var variableLength = 0;


### PR DESCRIPTION
- Precision value of `*` is now pulled from the list of Arguments. Previously this was not done, and the stack alignment was thrown off.

![image](https://user-images.githubusercontent.com/1139047/96181960-cab2d180-0f02-11eb-86fc-95d6b15103ea.png)

("Sysopaa" is actually the character name, since "Sysop" isn't accepted at creation 😛)

The original issue that caused this was MajorMUD used an `sprintf` format string `%-*.*s` which pulled both the length and precision from the list of arguments. While Length was being popped from the stack, Precision was not. Because of this, the stack was misaligned and the string result would be returned as `Invalid Pointer`