### PR TITLE
Fixed PLAYER NULL Error while Exiting MajorMUD

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/curusr_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/curusr_Tests.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class curusr_Tests : ExportedModuleTestBase
+    {
+        private const int CURUSR_ORDINAL = 151;
+
+        [Fact]
+        public void CURUSR_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, CURUSR_ORDINAL, new List<ushort> { 0xFF });
+
+            Assert.Equal(0xFF, mbbsEmuMemoryCore.GetWord("USRNUM"));
+        }
+    }
+}

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -4446,6 +4446,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var newUserNumber = GetParameter(0);
             ChannelNumber = newUserNumber;
 
+            Module.Memory.SetWord("USRNUM", newUserNumber);
+
 #if DEBUG
             _logger.Info($"Setting Current User to {newUserNumber}");
 #endif


### PR DESCRIPTION
- `CURUSR` was setting the private variable `CurrentChannel` in the class, but not setting the `USRNUM` property. This has been fixed.