### PR TITLE
Memory performance optimizations

### DIFF
--- a/MBBSEmu/Memory/IntPtr16.cs
+++ b/MBBSEmu/Memory/IntPtr16.cs
@@ -10,13 +10,21 @@ namespace MBBSEmu.Memory
         public ushort Segment
         {
             get => BitConverter.ToUInt16(Data, 2);
-            set => Array.Copy(BitConverter.GetBytes(value), 0, Data, 2, 2);
+            set
+            {
+                Data[2] = (byte)(value & 0xFF);
+                Data[3] = (byte)(value >> 8);
+            }
 
         }
         public ushort Offset
         {
             get => BitConverter.ToUInt16(Data, 0);
-            set => Array.Copy(BitConverter.GetBytes(value), 0, Data, 0, 2);
+            set
+            {
+                Data[0] = (byte)(value & 0xFF);
+                Data[1] = (byte)(value >> 8);
+            }
         }
 
         public readonly byte[] Data = new byte[Size];
@@ -141,10 +149,10 @@ namespace MBBSEmu.Memory
         public static IntPtr16 operator ++(IntPtr16 i) => new IntPtr16(i.Segment, (ushort)(i.Offset + 1));
         public static IntPtr16 operator --(IntPtr16 i) => new IntPtr16(i.Segment, (ushort)(i.Offset - 1));
 
-        public static bool operator > (IntPtr16 l, IntPtr16 r) => l.ToInt32() > r.ToInt32();
-        public static bool operator >= (IntPtr16 l, IntPtr16 r) => l.ToInt32() >= r.ToInt32();
+        public static bool operator >(IntPtr16 l, IntPtr16 r) => l.ToInt32() > r.ToInt32();
+        public static bool operator >=(IntPtr16 l, IntPtr16 r) => l.ToInt32() >= r.ToInt32();
 
-        public static bool operator < (IntPtr16 l, IntPtr16 r) => l.ToInt32() < r.ToInt32();
-        public static bool operator <= (IntPtr16 l, IntPtr16 r) => l.ToInt32() <= r.ToInt32();
+        public static bool operator <(IntPtr16 l, IntPtr16 r) => l.ToInt32() < r.ToInt32();
+        public static bool operator <=(IntPtr16 l, IntPtr16 r) => l.ToInt32() <= r.ToInt32();
     }
 }

--- a/MBBSEmu/Memory/MemoryCore.cs
+++ b/MBBSEmu/Memory/MemoryCore.cs
@@ -93,7 +93,7 @@ namespace MBBSEmu.Memory
             //    $"Variable {name ?? "NULL"} allocated {size} bytes of memory in Host Memory Segment {_currentVariablePointer.Segment:X4}:{_currentVariablePointer.Offset:X4}");
 #endif
             var currentOffset = _currentVariablePointer.Offset;
-            _currentVariablePointer.Offset += (ushort) (size + 1);
+            _currentVariablePointer.Offset += (ushort)(size + 1);
 
             var newPointer = new IntPtr16(_currentVariablePointer.Segment, currentOffset);
 
@@ -216,7 +216,7 @@ namespace MBBSEmu.Memory
                 var decoder = Decoder.Create(16, codeReader);
                 decoder.IP = 0x0;
 
-                while (decoder.IP < (ulong) segment.Data.Length)
+                while (decoder.IP < (ulong)segment.Data.Length)
                 {
                     decoder.Decode(out instructionList.AllocUninitializedElement());
                 }
@@ -476,8 +476,13 @@ namespace MBBSEmu.Memory
         /// <param name="segment"></param>
         /// <param name="offset"></param>
         /// <param name="value"></param>
-        public void SetWord(ushort segment, ushort offset, ushort value) =>
-            SetArray(segment, offset, BitConverter.GetBytes(value));
+        public void SetWord(ushort segment, ushort offset, ushort value)
+        {
+            _ = new Span<byte>(_memorySegments[segment])
+            {
+                [offset] = (byte) (value & 0xFF), [offset + 1] = (byte) (value >> 8)
+            };
+        }
 
         /// <summary>
         ///     Sets the specified word at the defined variable
@@ -496,17 +501,11 @@ namespace MBBSEmu.Memory
 
         public void SetArray(ushort segment, ushort offset, ReadOnlySpan<byte> array)
         {
-
-#if DEBUG
+            var destinationSpan = new Span<byte>(_memorySegments[segment]);
             for (var i = 0; i < array.Length; i++)
             {
-                _memorySegments[segment][offset + i] = array[i];
+                destinationSpan[offset++] = array[i];
             }
-#else
-
-            var destinationSpan = new Span<byte>(_memorySegments[segment], offset, array.Length);
-            array.CopyTo(destinationSpan);
-#endif
         }
 
         /// <summary>


### PR DESCRIPTION
Memory performance optimizations by reducing Framework calls on simple operations.

Optimizations took benchmark locally on an i9-9900k from 9 MIP to 12 MIPS in Release Mode.