### PR TITLE
Removing Cruft

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/Doscalls.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Doscalls.cs
@@ -40,7 +40,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #if DEBUG
                 //_logger.Info($"Returning Method Offset {methodPointer.Segment:X4}:{methodPointer.Offset:X4}");
 #endif
-                return methodPointer.ToSpan();
+                return methodPointer.Data;
             }
 
             switch (ordinal)

--- a/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
@@ -108,7 +108,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #if DEBUG
                 //_logger.Info($"Returning Method Offset {methodPointer.Segment:X4}:{methodPointer.Offset:X4}");
 #endif
-                return methodPointer.ToSpan();
+                return methodPointer.Data;
             }
 
             switch (ordinal)
@@ -241,7 +241,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Result: DX == Segment containing bturno
         /// </summary>
         /// <returns></returns>
-        public ReadOnlySpan<byte> bturno() => Module.Memory.GetVariablePointer("BTURNO").ToSpan();
+        public ReadOnlySpan<byte> bturno() => Module.Memory.GetVariablePointer("BTURNO").Data;
 
         /// <summary>
         ///     Report the amount of space (number of bytes) available in the output buffer
@@ -442,7 +442,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 return;
             }
 
-            ChannelDictionary[channel].CharacterInterceptor = new IntPtr16(routinePointer.ToSpan());
+            ChannelDictionary[channel].CharacterInterceptor = new IntPtr16(routinePointer.Data);
 
 #if DEBUG
             _logger.Info($"Assigned Character Interceptor Routine {ChannelDictionary[channel].CharacterInterceptor} to Channel {channel}");
@@ -759,7 +759,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             ChannelDictionary[MonitoredChannel2].DataToProcess = true;
         }
 
-        private ReadOnlySpan<byte> ticker => Module.Memory.GetVariablePointer("TICKER").ToSpan();
+        private ReadOnlySpan<byte> ticker => Module.Memory.GetVariablePointer("TICKER").Data;
 
         /// <summary>
         ///     Status of a Channel

--- a/MBBSEmu/HostProcess/ExportedModules/Galme.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galme.cs
@@ -39,7 +39,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #if DEBUG
                 //_logger.Info($"Returning Method Offset {methodPointer.Segment:X4}:{methodPointer.Offset:X4}");
 #endif
-                return methodPointer.ToSpan();
+                return methodPointer.Data;
             }
 
             switch (ordinal)
@@ -103,6 +103,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: unsigned txtlen(void)
         /// </summary>
-        private ReadOnlySpan<byte> _txtlen => Module.Memory.GetVariablePointer("TXTLEN").ToSpan();
+        private ReadOnlySpan<byte> _txtlen => Module.Memory.GetVariablePointer("TXTLEN").Data;
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Galmsg.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galmsg.cs
@@ -24,7 +24,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #if DEBUG
                 //_logger.Info($"Returning Method Offset {methodPointer.Segment:X4}:{methodPointer.Offset:X4}");
 #endif
-                return methodPointer.ToSpan();
+                return methodPointer.Data;
             }
 
             switch (ordinal)

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -104,11 +104,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.AllocateVariable("USRNUM", 0x2);
             var usraccPointer = Module.Memory.AllocateVariable("USRACC", (UserAccount.Size * NUMBER_OF_CHANNELS), true);
             var usaptrPointer = Module.Memory.AllocateVariable("USAPTR", 0x4);
-            Module.Memory.SetArray(usaptrPointer, usraccPointer.ToSpan());
+            Module.Memory.SetArray(usaptrPointer, usraccPointer.Data);
 
             var usrExtPointer = Module.Memory.AllocateVariable("EXTUSR", (ExtUser.Size * NUMBER_OF_CHANNELS), true);
             var extPtrPointer = Module.Memory.AllocateVariable("EXTPTR", 0x4);
-            Module.Memory.SetArray(extPtrPointer, usrExtPointer.ToSpan());
+            Module.Memory.SetArray(extPtrPointer, usrExtPointer.Data);
 
             Module.Memory.AllocateVariable("OTHUAP", 0x04, true); //Pointer to OTHER user
             Module.Memory.AllocateVariable("OTHEXP", 0x04, true); //Pointer to OTHER user
@@ -124,7 +124,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var modulePointer = Module.Memory.AllocateVariable("MODULE", 0x4); //Pointer to Registered Module
             var modulePointerPointer =
                 Module.Memory.AllocateVariable("MODULE-POINTER", 0x4); //Pointer to the Module Pointer
-            Module.Memory.SetArray(modulePointerPointer, modulePointer.ToSpan());
+            Module.Memory.SetArray(modulePointerPointer, modulePointer.Data);
             Module.Memory.AllocateVariable("UACOFF", 0x4);
             Module.Memory.AllocateVariable("EXTOFF", 0x4);
             Module.Memory.AllocateVariable("VDAPTR", 0x4);
@@ -257,36 +257,36 @@ namespace MBBSEmu.HostProcess.ExportedModules
             if (!Module.Memory.TryGetVariablePointer($"VDA-{channelNumber}", out var vdaChannelPointer))
                 vdaChannelPointer = Module.Memory.AllocateVariable($"VDA-{channelNumber}", VOLATILE_DATA_SIZE);
 
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("VDAPTR"), vdaChannelPointer.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("VDAPTR"), vdaChannelPointer.Data);
             Module.Memory.SetWord(Module.Memory.GetVariablePointer("USRNUM"), channelNumber);
 
             ChannelDictionary[channelNumber].StatusChange = false;
             Module.Memory.SetWord(Module.Memory.GetVariablePointer("STATUS"), ChannelDictionary[channelNumber].Status);
 
             var userBasePointer = Module.Memory.GetVariablePointer("USER");
-            var currentUserPointer = new IntPtr16(userBasePointer.ToSpan());
+            var currentUserPointer = new IntPtr16(userBasePointer.Data);
             currentUserPointer.Offset += (ushort)(User.Size * channelNumber);
 
             //Update User Array and Update Pointer to point to this user
             Module.Memory.SetArray(currentUserPointer, ChannelDictionary[channelNumber].UsrPtr.Data);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("*USRPTR"), currentUserPointer.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("*USRPTR"), currentUserPointer.Data);
 
             var userAccBasePointer = Module.Memory.GetVariablePointer("USRACC");
-            var currentUserAccPointer = new IntPtr16(userAccBasePointer.ToSpan());
+            var currentUserAccPointer = new IntPtr16(userAccBasePointer.Data);
             currentUserAccPointer.Offset += (ushort)(UserAccount.Size * channelNumber);
             Module.Memory.SetArray(currentUserAccPointer, ChannelDictionary[channelNumber].UsrAcc.Data);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("USAPTR"), currentUserAccPointer.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("USAPTR"), currentUserAccPointer.Data);
 
             var userExtAccBasePointer = Module.Memory.GetVariablePointer("EXTUSR");
-            var currentExtUserAccPointer = new IntPtr16(userExtAccBasePointer.ToSpan());
+            var currentExtUserAccPointer = new IntPtr16(userExtAccBasePointer.Data);
             currentExtUserAccPointer.Offset += (ushort)(ExtUser.Size * channelNumber);
             Module.Memory.SetArray(currentExtUserAccPointer, ChannelDictionary[channelNumber].ExtUsrAcc.Data);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("EXTPTR"), currentExtUserAccPointer.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("EXTPTR"), currentExtUserAccPointer.Data);
 
             //Write Blank Input
             var inputMemory = Module.Memory.GetVariablePointer("INPUT");
             Module.Memory.SetByte(inputMemory.Segment, inputMemory.Offset, 0x0);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("NXTCMD"), inputMemory.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("NXTCMD"), inputMemory.Data);
 
             //Reset PRFPTR
             Module.Memory.SetPointer("PRFPTR", Module.Memory.GetVariablePointer("PRFBUF"));
@@ -501,7 +501,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             if (offsetsOnly)
             {
-                return new IntPtr16(Segment, ordinal).ToSpan();
+                return new IntPtr16(Segment, ordinal).Data;
             }
 
             switch (ordinal)
@@ -1374,7 +1374,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private void register_module()
         {
             var destinationPointer = GetParameterPointer(0);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("MODULE"), destinationPointer.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("MODULE"), destinationPointer.Data);
 
             var moduleStruct = Module.Memory.GetArray(destinationPointer, 61);
 
@@ -1698,7 +1698,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Retrurns: int == User Number (Channel)
         /// </summary>
         /// <returns></returns>
-        private ReadOnlySpan<byte> usrnum => base.Module.Memory.GetVariablePointer("USRNUM").ToSpan();
+        private ReadOnlySpan<byte> usrnum => base.Module.Memory.GetVariablePointer("USRNUM").Data;
 
         /// <summary>
         ///     Gets the online user account info
@@ -1725,7 +1725,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             //Set Pointer to new user array
             var uacoffPointer = Module.Memory.GetVariablePointer("UACOFF");
-            Module.Memory.SetArray(uacoffPointer, variablePointer.ToSpan());
+            Module.Memory.SetArray(uacoffPointer, variablePointer.Data);
 
             //Set User Array Value
             Module.Memory.SetArray(variablePointer, userChannel.UsrAcc.Data);
@@ -1839,7 +1839,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Signature: struct user *usrptr;
         /// </summary>
         /// <returns></returns>
-        private ReadOnlySpan<byte> usrptr => Module.Memory.GetVariablePointer("*USRPTR").ToSpan();
+        private ReadOnlySpan<byte> usrptr => Module.Memory.GetVariablePointer("*USRPTR").Data;
 
         /// <summary>
         ///     Like prf(), but the control string comes from an .MCV file
@@ -1916,7 +1916,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 }
 
                 Module.Memory.SetArray(pointer, arrayOutput);
-                return pointer.ToSpan();
+                return pointer.Data;
             }
         }
 
@@ -2165,7 +2165,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //If there's an MVC currently set, push it to the queue
             if (_currentMcvFile != null)
             {
-                _previousMcvFile.Push(new IntPtr16(_currentMcvFile.ToSpan()));
+                _previousMcvFile.Push(new IntPtr16(_currentMcvFile.Data));
 #if DEBUG
                 _logger.Info("Enqueue Previous MCV File: {0} (Pointer: {1})",
                     McvPointerDictionary[_currentMcvFile.Offset].FileName, _currentMcvFile);
@@ -2416,7 +2416,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Returns: Segment holding the Users Status
         /// </summary>
         /// <returns></returns>
-        private ReadOnlySpan<byte> status => Module.Memory.GetVariablePointer("STATUS").ToSpan();
+        private ReadOnlySpan<byte> status => Module.Memory.GetVariablePointer("STATUS").Data;
 
         /// <summary>
         ///     Deduct real credits from online acct
@@ -2643,7 +2643,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: char *prfbuf
         /// </summary>
-        private ReadOnlySpan<byte> prfbuf => Module.Memory.GetVariablePointer("*PRFBUF").ToSpan();
+        private ReadOnlySpan<byte> prfbuf => Module.Memory.GetVariablePointer("*PRFBUF").Data;
 
         /// <summary>
         ///     Copies characters from a string
@@ -2771,7 +2771,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #endif
         }
 
-        private ReadOnlySpan<byte> nterms => Module.Memory.GetVariablePointer("NTERMS").ToSpan();
+        private ReadOnlySpan<byte> nterms => Module.Memory.GetVariablePointer("NTERMS").Data;
 
         /// <summary>
         ///     Compute volatile data pointer for the specified User Number
@@ -2804,14 +2804,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///     Signature: struct user;
         /// </summary>
         /// <returns></returns>
-        private ReadOnlySpan<byte> user
-        {
-            get
-            {
-                var pointer = Module.Memory.GetVariablePointer("*USER");
-                return pointer.ToSpan();
-            }
-        }
+        private ReadOnlySpan<byte> user => Module.Memory.GetVariablePointer("*USER").Data;
+         
 
         /// <summary>
         ///     Points to the Volatile Data Area for the current channel
@@ -2825,7 +2819,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 if (!Module.Memory.TryGetVariablePointer($"VDAPTR", out var variablePointer))
                     variablePointer = Module.Memory.AllocateVariable($"VDAPTR", 0x4);
 
-                return variablePointer.ToSpan();
+                return variablePointer.Data;
             }
         }
 
@@ -2847,13 +2841,13 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: int margc
         /// </summary>
-        private ReadOnlySpan<byte> margc => Module.Memory.GetVariablePointer("MARGC").ToSpan();
+        private ReadOnlySpan<byte> margc => Module.Memory.GetVariablePointer("MARGC").Data;
 
         /// <summary>
         ///     Returns the pointer to the next parsed input command from the user
         ///     If this is the first time it's called, it returns the first command
         /// </summary>
-        private ReadOnlySpan<byte> nxtcmd => Module.Memory.GetVariablePointer("NXTCMD").ToSpan();
+        private ReadOnlySpan<byte> nxtcmd => Module.Memory.GetVariablePointer("NXTCMD").Data;
 
         /// <summary>
         ///     Case-ignoring substring match
@@ -2962,7 +2956,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: char *prfptr;
         /// </summary>
-        private ReadOnlySpan<byte> prfptr => Module.Memory.GetVariablePointer("PRFPTR").ToSpan();
+        private ReadOnlySpan<byte> prfptr => Module.Memory.GetVariablePointer("PRFPTR").Data;
 
         private bool FileAlreadyOpen(string fullPath, out IntPtr16 fileStructPointer)
         {
@@ -3331,7 +3325,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: char input[]
         /// </summary>
-        private ReadOnlySpan<byte> input => Module.Memory.GetVariablePointer("INPUT").ToSpan();
+        private ReadOnlySpan<byte> input => Module.Memory.GetVariablePointer("INPUT").Data;
 
         /// <summary>
         ///     Converts a lowercase letter to uppercase
@@ -3414,11 +3408,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: int inplen
         /// </summary>
-        private ReadOnlySpan<byte> inplen => Module.Memory.GetVariablePointer("INPLEN").ToSpan();
+        private ReadOnlySpan<byte> inplen => Module.Memory.GetVariablePointer("INPLEN").Data;
 
-        private ReadOnlySpan<byte> margv => Module.Memory.GetVariablePointer("MARGV").ToSpan();
+        private ReadOnlySpan<byte> margv => Module.Memory.GetVariablePointer("MARGV").Data;
 
-        private ReadOnlySpan<byte> margn => Module.Memory.GetVariablePointer("MARGN").ToSpan();
+        private ReadOnlySpan<byte> margn => Module.Memory.GetVariablePointer("MARGN").Data;
 
         /// <summary>
         ///     Restore parsed input line (undoes effects of parsin())
@@ -3443,8 +3437,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private ReadOnlySpan<byte> _exitbuf => new byte[] { 0x0, 0x0, 0x0, 0x0 };
         private ReadOnlySpan<byte> _exitfopen => new byte[] { 0x0, 0x0, 0x0, 0x0 };
         private ReadOnlySpan<byte> _exitopen => new byte[] { 0x0, 0x0, 0x0, 0x0 };
-        private ReadOnlySpan<byte> extptr => Module.Memory.GetVariablePointer("EXTPTR").ToSpan();
-        private ReadOnlySpan<byte> usaptr => Module.Memory.GetVariablePointer("USAPTR").ToSpan();
+        private ReadOnlySpan<byte> extptr => Module.Memory.GetVariablePointer("EXTPTR").Data;
+        private ReadOnlySpan<byte> usaptr => Module.Memory.GetVariablePointer("USAPTR").Data;
 
         /// <summary>
         ///     Appends the first num characters of source to destination, plus a terminating null-character.
@@ -4102,17 +4096,17 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var othusnPointer = Module.Memory.GetVariablePointer("OTHUSN");
             Module.Memory.SetWord(othusnPointer, ChannelDictionary[userSession.Channel].Channel);
 
-            var userBase = new IntPtr16(Module.Memory.GetVariablePointer("USER").ToSpan());
+            var userBase = new IntPtr16(Module.Memory.GetVariablePointer("USER").Data);
             userBase.Offset += (ushort)(User.Size * userSession.Channel);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHUSP"), userBase.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHUSP"), userBase.Data);
 
-            var userAccBase = new IntPtr16(Module.Memory.GetVariablePointer("USRACC").ToSpan());
+            var userAccBase = new IntPtr16(Module.Memory.GetVariablePointer("USRACC").Data);
             userAccBase.Offset += (ushort)(UserAccount.Size * userSession.Channel);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHUAP"), userAccBase.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHUAP"), userAccBase.Data);
 
-            var userExtAcc = new IntPtr16(Module.Memory.GetVariablePointer("EXTUSR").ToSpan());
+            var userExtAcc = new IntPtr16(Module.Memory.GetVariablePointer("EXTUSR").Data);
             userExtAcc.Offset += (ushort)(ExtUser.Size * userSession.Channel);
-            Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHEXP"), userExtAcc.ToSpan());
+            Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHEXP"), userExtAcc.Data);
 
 #if DEBUG
             _logger.Info($"User Found -- Channel {userSession.Channel}, user[] offset {userBase}");
@@ -4312,7 +4306,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Registers.AX = numRemoved;
         }
 
-        private ReadOnlySpan<byte> othusn => Module.Memory.GetVariablePointer("OTHUSN").ToSpan();
+        private ReadOnlySpan<byte> othusn => Module.Memory.GetVariablePointer("OTHUSN").Data;
 
         /// <summary>
         ///     Returns number of bytes session will need, or -1=error in data
@@ -4456,7 +4450,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <summary>
         ///     Number of modules currently installed
         /// </summary>
-        private ReadOnlySpan<byte> nmods => Module.Memory.GetVariablePointer("NMODS").ToSpan();
+        private ReadOnlySpan<byte> nmods => Module.Memory.GetVariablePointer("NMODS").Data;
 
         /// <summary>
         ///     This is the pointer, to the pointer, for the MODULE struct because module is declared
@@ -4464,7 +4458,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Pointer -> Pointer -> Struct
         /// </summary>
-        private ReadOnlySpan<byte> module => Module.Memory.GetVariablePointer("MODULE-POINTER").ToSpan();
+        private ReadOnlySpan<byte> module => Module.Memory.GetVariablePointer("MODULE-POINTER").Data;
 
         /// <summary>
         ///     Long Arithmatic Shift Left (Borland C++ Implicit Function)
@@ -4530,14 +4524,14 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     See: CTYPE.H
         /// </summary>
-        private ReadOnlySpan<byte> _ctype => Module.Memory.GetVariablePointer("CTYPE").ToSpan();
+        private ReadOnlySpan<byte> _ctype => Module.Memory.GetVariablePointer("CTYPE").Data;
 
         /// <summary>
         ///     Points to the ad-hoc Volatile Data Area
         ///
         ///     Signature: char *vdatmp
         /// </summary>
-        private ReadOnlySpan<byte> vdatmp => Module.Memory.GetVariablePointer("*VDATMP").ToSpan();
+        private ReadOnlySpan<byte> vdatmp => Module.Memory.GetVariablePointer("*VDATMP").Data;
 
         /// <summary>
         ///     Send prfbuf to a channel & clear
@@ -4679,7 +4673,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 var titlePointer = Module.Memory.GetVariablePointer("BBSTTL");
 
                 Module.Memory.SetArray(titlePointer, Encoding.ASCII.GetBytes(title));
-                return Module.Memory.GetVariablePointer("*BBSTTL").ToSpan();
+                return Module.Memory.GetVariablePointer("*BBSTTL").Data;
             }
         }
 
@@ -4703,7 +4697,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 var titlePointer = Module.Memory.GetVariablePointer("COMPANY");
 
                 Module.Memory.SetArray(titlePointer, Encoding.ASCII.GetBytes(title));
-                return Module.Memory.GetVariablePointer("*COMPANY").ToSpan();
+                return Module.Memory.GetVariablePointer("*COMPANY").Data;
             }
         }
 
@@ -4727,7 +4721,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 var titlePointer = Module.Memory.GetVariablePointer("ADDRES1");
 
                 Module.Memory.SetArray(titlePointer, Encoding.ASCII.GetBytes(title));
-                return Module.Memory.GetVariablePointer("*ADDRES1").ToSpan();
+                return Module.Memory.GetVariablePointer("*ADDRES1").Data;
             }
         }
 
@@ -4751,7 +4745,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 var titlePointer = Module.Memory.GetVariablePointer("ADDRES2");
 
                 Module.Memory.SetArray(titlePointer, Encoding.ASCII.GetBytes(title));
-                return Module.Memory.GetVariablePointer("*ADDRES2").ToSpan();
+                return Module.Memory.GetVariablePointer("*ADDRES2").Data;
             }
         }
 
@@ -4775,7 +4769,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 var titlePointer = Module.Memory.GetVariablePointer("DATAPH");
 
                 Module.Memory.SetArray(titlePointer, Encoding.ASCII.GetBytes(title));
-                return Module.Memory.GetVariablePointer("*DATAPH").ToSpan();
+                return Module.Memory.GetVariablePointer("*DATAPH").Data;
             }
         }
 
@@ -4799,7 +4793,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 var titlePointer = Module.Memory.GetVariablePointer("LIVEPH");
 
                 Module.Memory.SetArray(titlePointer, Encoding.ASCII.GetBytes(title));
-                return Module.Memory.GetVariablePointer("*LIVEPH").ToSpan();
+                return Module.Memory.GetVariablePointer("*LIVEPH").Data;
             }
         }
 
@@ -4860,7 +4854,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: int vdasiz;
         /// </summary>
-        private ReadOnlySpan<byte> vdasiz => Module.Memory.GetVariablePointer("VDASIZ").ToSpan();
+        private ReadOnlySpan<byte> vdasiz => Module.Memory.GetVariablePointer("VDASIZ").Data;
 
         /// <summary>
         ///     Performs a Btrieve Query Operation based on KEYS
@@ -4972,21 +4966,21 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: struct user *othusp;
         /// </summary>
-        private ReadOnlySpan<byte> othusp => Module.Memory.GetVariablePointer("*OTHUSP").ToSpan();
+        private ReadOnlySpan<byte> othusp => Module.Memory.GetVariablePointer("*OTHUSP").Data;
 
         /// <summary>
         ///     Pointer to structure for that user in the extusr structure (set by onsys() or instat())
         ///
         ///     Signature: struct extusr *othexp;
         /// </summary>
-        private ReadOnlySpan<byte> othexp => Module.Memory.GetVariablePointer("*OTHEXP").ToSpan();
+        private ReadOnlySpan<byte> othexp => Module.Memory.GetVariablePointer("*OTHEXP").Data;
 
         /// <summary>
         ///     Pointer to structure for that user in the 'usracc' structure (set by onsys() or instat())
         ///
         ///     Signature: struct usracc *othuap;
         /// </summary>
-        private ReadOnlySpan<byte> othuap => Module.Memory.GetVariablePointer("*OTHUAP").ToSpan();
+        private ReadOnlySpan<byte> othuap => Module.Memory.GetVariablePointer("*OTHUAP").Data;
 
         /// <summary>
         ///     Splits the specified string into tokens based on the delimiters
@@ -5401,7 +5395,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             //Set Pointer to new user array
             var extoffPointer = Module.Memory.GetVariablePointer("EXTOFF");
-            Module.Memory.SetArray(extoffPointer, variablePointer.ToSpan());
+            Module.Memory.SetArray(extoffPointer, variablePointer.Data);
 
             //Set User Array Value
             Module.Memory.SetArray(variablePointer, userChannel.ExtUsrAcc.Data);
@@ -5668,14 +5662,14 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: int mmucrr
         /// </summary>
-        private ReadOnlySpan<byte> mmuccr => Module.Memory.GetVariablePointer("MMUCCR").ToSpan();
+        private ReadOnlySpan<byte> mmuccr => Module.Memory.GetVariablePointer("MMUCCR").Data;
 
         /// <summary>
         ///     'Profanity Level' of the Input (from configuration)
         ///
         ///     This is hard coded to 0, which means no profanity detected
         /// </summary>
-        private ReadOnlySpan<byte> pfnlvl => Module.Memory.GetVariablePointer("PFNLVL").ToSpan();
+        private ReadOnlySpan<byte> pfnlvl => Module.Memory.GetVariablePointer("PFNLVL").Data;
 
         /// <summary>
         ///     Long Unsigned Division (Borland C++ Implicit Function)
@@ -5896,7 +5890,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Registers.AX = (ushort)ChannelDictionary.Count;
         }
 
-        private ReadOnlySpan<byte> version => Module.Memory.GetVariablePointer("VERSION").ToSpan();
+        private ReadOnlySpan<byte> version => Module.Memory.GetVariablePointer("VERSION").Data;
 
         /// <summary>
         ///     access - determines accessibility of a file
@@ -6147,7 +6141,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             _galacticommClientServerAgent = new AgentStruct(Module.Memory.GetArray(agentPointer, AgentStruct.Size));
         }
 
-        private ReadOnlySpan<byte> syscyc => Module.Memory.GetVariablePointer("SYSCYC").ToSpan();
+        private ReadOnlySpan<byte> syscyc => Module.Memory.GetVariablePointer("SYSCYC").Data;
 
         /// <summary>
         ///     Read a CNF option from a .MSG file
@@ -6228,10 +6222,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
         }
 
-        private ReadOnlySpan<byte> numfils => Module.Memory.GetVariablePointer("NUMFILS").ToSpan();
-        private ReadOnlySpan<byte> numbyts => Module.Memory.GetVariablePointer("NUMBYTS").ToSpan();
-        private ReadOnlySpan<byte> numbytp => Module.Memory.GetVariablePointer("NUMBYTP").ToSpan();
-        private ReadOnlySpan<byte> numdirs => Module.Memory.GetVariablePointer("NUMDIRS").ToSpan();
+        private ReadOnlySpan<byte> numfils => Module.Memory.GetVariablePointer("NUMFILS").Data;
+        private ReadOnlySpan<byte> numbyts => Module.Memory.GetVariablePointer("NUMBYTS").Data;
+        private ReadOnlySpan<byte> numbytp => Module.Memory.GetVariablePointer("NUMBYTP").Data;
+        private ReadOnlySpan<byte> numdirs => Module.Memory.GetVariablePointer("NUMDIRS").Data;
 
         /// <summary>
         ///     Closes the Specified Btrieve File
@@ -6250,7 +6244,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             _currentMcvFile = null;
         }
 
-        private ReadOnlySpan<byte> nglobs => Module.Memory.GetVariablePointer("NGLOBS").ToSpan();
+        private ReadOnlySpan<byte> nglobs => Module.Memory.GetVariablePointer("NGLOBS").Data;
 
         /// <summary>
         ///     Retrieves a C-string containing the value of the environment variable whose name is specified in the argument
@@ -6349,35 +6343,35 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: struct ftg *ftgptr;
         /// </summary>
-        private ReadOnlySpan<byte> ftgptr => Module.Memory.GetVariablePointer("FTGPTR").ToSpan();
+        private ReadOnlySpan<byte> ftgptr => Module.Memory.GetVariablePointer("FTGPTR").Data;
 
         /// <summary>
         ///     Universal global Tagspec Handler messag
         ///
         ///     Signature: char tshmsg[TSHLEN+1];
         /// </summary>
-        private ReadOnlySpan<byte> tshmsg => Module.Memory.GetVariablePointer("TSHMSG").ToSpan();
+        private ReadOnlySpan<byte> tshmsg => Module.Memory.GetVariablePointer("TSHMSG").Data;
 
         /// <summary>
         ///     (File Transfer) Contains fields for external use
         ///
         ///     Signature: struct ftfscb {...};
         /// </summary>
-        private ReadOnlySpan<byte> ftfscb => Module.Memory.GetVariablePointer("FTFSCB").ToSpan();
+        private ReadOnlySpan<byte> ftfscb => Module.Memory.GetVariablePointer("FTFSCB").Data;
 
         /// <summary>
         ///     Output buffer size per channel
         ///
         ///     Signature: int outbsz;
         /// </summary>
-        private ReadOnlySpan<byte> outbsz => Module.Memory.GetVariablePointer("OUTBSZ").ToSpan();
+        private ReadOnlySpan<byte> outbsz => Module.Memory.GetVariablePointer("OUTBSZ").Data;
 
         /// <summary>
         ///     System-Variable Btrieve Record Layout Struct (1 of 3)
         ///
         ///     Signature: struct sysvbl sv;
         /// </summary>
-        private ReadOnlySpan<byte> sv => Module.Memory.GetVariablePointer("SV").ToSpan();
+        private ReadOnlySpan<byte> sv => Module.Memory.GetVariablePointer("SV").Data;
 
         /// <summary>
         ///     List an ASCII file to the users screen
@@ -6458,7 +6452,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: char eurmsk;
         /// </summary>
-        private ReadOnlySpan<byte> eurmsk => Module.Memory.GetVariablePointer("EURMSK").ToSpan();
+        private ReadOnlySpan<byte> eurmsk => Module.Memory.GetVariablePointer("EURMSK").Data;
 
         /// <summary>
         ///     strnicmp - compare one string to another without case sensitivity
@@ -6636,14 +6630,14 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: struct fsdscb *fsdscb;
         /// </summary>
-        private ReadOnlySpan<byte> fsdscb => Module.Memory.GetVariablePointer("*FSDSCB").ToSpan();
+        private ReadOnlySpan<byte> fsdscb => Module.Memory.GetVariablePointer("*FSDSCB").Data;
 
         /// <summary>
         ///     Current btvu file pointer set
         ///
         ///     Signature: struct btvblk *bb;
         /// </summary>
-        private ReadOnlySpan<byte> bb => Module.Memory.GetVariablePointer("BB").ToSpan();
+        private ReadOnlySpan<byte> bb => Module.Memory.GetVariablePointer("BB").Data;
 
         /// <summary>
         ///     Convert a string to a long integer
@@ -6785,7 +6779,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     Signature: char fsdemg[];
         /// </summary>
-        private ReadOnlySpan<byte> fsdemg => Module.Memory.GetVariablePointer("FSDEMG").ToSpan();
+        private ReadOnlySpan<byte> fsdemg => Module.Memory.GetVariablePointer("FSDEMG").Data;
 
         /// <summary>
         ///     Factory-issue field verify routine, for ask-done-at-end scheme
@@ -7083,7 +7077,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         ///
         ///     This is "SYSOP" by default
         /// </summary>
-        private ReadOnlySpan<byte> syskey => Module.Memory.GetVariablePointer("*SYSKEY").ToSpan();
+        private ReadOnlySpan<byte> syskey => Module.Memory.GetVariablePointer("*SYSKEY").Data;
 
         /// <summary>
         ///     "strip" blank spaces after input

--- a/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
@@ -36,7 +36,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #if DEBUG
                 //_logger.Info($"Returning Method Offset {methodPointer.Segment:X4}:{methodPointer.Offset:X4}");
 #endif
-                return methodPointer.ToSpan();
+                return methodPointer.Data;
             }
 
             switch (ordinal)

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -926,7 +926,7 @@ namespace MBBSEmu.HostProcess
                                 //32-Bit Pointer
                                 if (relocationRecord.SourceType == 3)
                                 {
-                                    Array.Copy(relocationPointer.ToArray(), 0, s.Data, relocationRecord.Offset, 4);
+                                    Array.Copy(relocationPointer.Data, 0, s.Data, relocationRecord.Offset, 4);
                                     continue;
                                 }
 
@@ -955,7 +955,7 @@ namespace MBBSEmu.HostProcess
                                     var relocationPointer = new IntPtr16(relocationRecord.TargetTypeValueTuple.Item2,
                                         relocationRecord.TargetTypeValueTuple.Item4);
 
-                                    Array.Copy(relocationPointer.ToArray(), 0, s.Data, relocationRecord.Offset, 4);
+                                    Array.Copy(relocationPointer.Data, 0, s.Data, relocationRecord.Offset, 4);
                                     break;
                                 }
                                 Array.Copy(BitConverter.GetBytes(relocationRecord.TargetTypeValueTuple.Item2), 0, s.Data, relocationRecord.Offset, 2);
@@ -985,7 +985,7 @@ namespace MBBSEmu.HostProcess
                                 //32-Bit Pointer
                                 if (relocationRecord.SourceType == 3)
                                 {
-                                    Array.Copy(relocationPointer.ToArray(), 0, s.Data, relocationRecord.Offset, 4);
+                                    Array.Copy(relocationPointer.Data, 0, s.Data, relocationRecord.Offset, 4);
                                     continue;
                                 }
 

--- a/MBBSEmu/HostProcess/Structs/BtvfileStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/BtvfileStruct.cs
@@ -48,7 +48,7 @@ namespace MBBSEmu.HostProcess.Structs
                 ReadOnlySpan<byte> btvFileStructSpan = Data;
                 return new IntPtr16(btvFileStructSpan.Slice(128, 4));
             }
-            set => Array.Copy(value.ToArray(), 0, Data, 128, 4);
+            set => Array.Copy(value.Data, 0, Data, 128, 4);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace MBBSEmu.HostProcess.Structs
                 ReadOnlySpan<byte> btvFileStructSpan = Data;
                 return new IntPtr16(btvFileStructSpan.Slice(134, 4));
             }
-            set => Array.Copy(value.ToArray(), 0, Data, 134, 4);
+            set => Array.Copy(value.Data, 0, Data, 134, 4);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace MBBSEmu.HostProcess.Structs
                 ReadOnlySpan<byte> btvFileStructSpan = Data;
                 return new IntPtr16(btvFileStructSpan.Slice(138, 4));
             }
-            set => Array.Copy(value.ToArray(), 0, Data, 138, 4);
+            set => Array.Copy(value.Data, 0, Data, 138, 4);
         }
 
         public readonly byte[] Data = new byte[192];

--- a/MBBSEmu/HostProcess/Structs/FileStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/FileStruct.cs
@@ -82,7 +82,7 @@ namespace MBBSEmu.HostProcess.Structs
                 ReadOnlySpan<byte> fileSpan = Data;
                 return new IntPtr16(fileSpan.Slice(8,4));
             }
-            set => Array.Copy(value.ToArray(), 0, Data, 8, 4);
+            set => Array.Copy(value.Data, 0, Data, 8, 4);
         }
 
         //Current active pointer [12-15]
@@ -92,7 +92,7 @@ namespace MBBSEmu.HostProcess.Structs
                 ReadOnlySpan<byte> fileSpan = Data;
                 return new IntPtr16(fileSpan.Slice(12, 4));
             }
-            set => Array.Copy(value.ToArray(), 0, Data, 12, 4);
+            set => Array.Copy(value.Data, 0, Data, 12, 4);
         }
 
         //Temporary file indicator [16]

--- a/MBBSEmu/HostProcess/Structs/FsdscbStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/FsdscbStruct.cs
@@ -16,7 +16,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 fldspc
         {
             get => new IntPtr16(Data);
-            set => Array.Copy(value.ToArray(), 0, Data, 0, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 0, IntPtr16.Size);
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 flddat
         {
             get => new IntPtr16(Data, 4);
-            set => Array.Copy(value.ToArray(), 0, Data, 4, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 4, IntPtr16.Size);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 mbpunc
         {
             get => new IntPtr16(Data, 8);
-            set => Array.Copy(value.ToArray(), 0, Data, 8, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 8, IntPtr16.Size);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 newans
         {
             get => new IntPtr16(Data, 12);
-            set => Array.Copy(value.ToArray(), 0, Data, 12, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 12, IntPtr16.Size);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 fldvfy
         {
             get => new IntPtr16(Data, 16);
-            set => Array.Copy(value.ToArray(), 0, Data, 16, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 16, IntPtr16.Size);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 ftmptr
         {
             get => new IntPtr16(Data, 153);
-            set => Array.Copy(value.ToArray(), 0, Data, 153, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 153, IntPtr16.Size);
         }
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 altptr
         {
             get => new IntPtr16(Data, 158);
-            set => Array.Copy(value.ToArray(), 0, Data, 158, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 158, IntPtr16.Size);
         }
 
         /// <summary>

--- a/MBBSEmu/HostProcess/Structs/FtgStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/FtgStruct.cs
@@ -41,7 +41,7 @@ namespace MBBSEmu.HostProcess.Structs
                 ReadOnlySpan<byte> dataSpan = Data;
                 return new IntPtr16(dataSpan.Slice(18,4));
             }
-            set => Array.Copy(value.ToArray(), 0, Data, 18, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 18, IntPtr16.Size);
         }
 
         public readonly byte[] Data;

--- a/MBBSEmu/HostProcess/Structs/User.cs
+++ b/MBBSEmu/HostProcess/Structs/User.cs
@@ -18,7 +18,7 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 Keys
         {
             get => new IntPtr16(new ReadOnlySpan<byte>(Data).Slice(2,4));
-            set => Array.Copy(value.ToArray(), 0, Data, 2, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 2, IntPtr16.Size);
         }
 
         public short State
@@ -96,13 +96,13 @@ namespace MBBSEmu.HostProcess.Structs
         public IntPtr16 Clsptr
         {
             get => new IntPtr16(new ReadOnlySpan<byte>(Data).Slice(32, 4));
-            set => Array.Copy(value.ToArray(), 0, Data, 32, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 32, IntPtr16.Size);
         }
 
         public IntPtr16 Polrou
         {
             get => new IntPtr16(new ReadOnlySpan<byte>(Data).Slice(36, 4));
-            set => Array.Copy(value.ToArray(), 0, Data, 36, IntPtr16.Size);
+            set => Array.Copy(value.Data, 0, Data, 36, IntPtr16.Size);
         }
 
         public byte lcstat

--- a/MBBSEmu/Memory/IntPtr16.cs
+++ b/MBBSEmu/Memory/IntPtr16.cs
@@ -55,19 +55,7 @@ namespace MBBSEmu.Memory
         ///     Returns the int16:int16 pointer as a 32-bit value
         /// </summary>
         /// <returns></returns>
-        public int ToInt32() => BitConverter.ToInt32(ToSpan());
-
-        /// <summary>
-        ///     Returns the int16:int16 pointer as a byte[]
-        /// </summary>
-        /// <returns></returns>
-        public byte[] ToArray() => Data;
-
-        /// <summary>
-        ///     Returns a reference to the int16:int16 pointer
-        /// </summary>
-        /// <returns></returns>
-        public ReadOnlySpan<byte> ToSpan() => Data;
+        public int ToInt32() => (Segment << 16) | Offset;
 
         /// <summary>
         ///     Returns the int16:int16 pointer as a string

--- a/MBBSEmu/Memory/MemoryCore.cs
+++ b/MBBSEmu/Memory/MemoryCore.cs
@@ -107,7 +107,7 @@ namespace MBBSEmu.Memory
                 if (declarePointer)
                 {
                     var variablePointer = AllocateVariable($"*{name}", 0x4, false);
-                    SetArray(variablePointer, newPointer.ToSpan());
+                    SetArray(variablePointer, newPointer.Data);
                 }
             }
 


### PR DESCRIPTION
- Refactored calls to .ToSpan() with reference Data
- Refactored calls to .ToArray() with reference Data

This was all left over from eary on in MBBSEmu development when IntPtr16 didn't have a backing byte[]