### PR TITLE
APPSettings Default Keys - Changed from Null -> .Exists

### DIFF
--- a/MBBSEmu/Configuration.cs
+++ b/MBBSEmu/Configuration.cs
@@ -56,7 +56,7 @@ namespace MBBSEmu
         {
             get
             {
-                if (ConfigurationRoot.GetSection("Account.DefaultKeys") == null)
+                if (!ConfigurationRoot.GetSection("Account.DefaultKeys").Exists())
                     return new[] { "DEMO", "NORMAL" };
 
                 return ConfigurationRoot.GetSection("Account.DefaultKeys").GetChildren()


### PR DESCRIPTION
If this setting was not specified it was actually showing as blank/empty so it was not defaulting.

Debugged using .Exists() and this detects when setting is missing and gives default keys