### PR TITLE
Update Login Routine

### DIFF
--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -289,10 +289,12 @@ namespace MBBSEmu.HostProcess.HostRoutines
             if (account == null)
             {
                 EchoToClient(session, "\r\n|B||RED|Invalid Credentials|RESET|\r\n".EncodeToANSIArray());
+                session.Username = "";
                 session.SessionState = EnumSessionState.LoginUsernameDisplay;
                 return;
             }
 
+            session.Username = account.userName;
             session.SessionState = EnumSessionState.LoginRoutines;
             session.SessionTimer.Start();
         }


### PR DESCRIPTION
-Added command to reset username on failed login
-Set users Session.username equal to what is in the account file
-MajorBBS likes to capitalize the first letter unless the rest is caps then it seems to go with the flow, did not add this logic
-MBBSEmu takes whatever capitalization the users enters initially and that will persist through future logins

Closes #280 
Closes #279 

Examples from MajorBBS:
![MBBSUserID](https://user-images.githubusercontent.com/27604078/98614073-4f53fe00-22bd-11eb-8f9c-0b0cb258ed20.jpg)
![MBBSUserID2](https://user-images.githubusercontent.com/27604078/98614079-524eee80-22bd-11eb-8040-e1a5e7524162.jpg)
![MBBSUserID3](https://user-images.githubusercontent.com/27604078/98614084-54b14880-22bd-11eb-9af1-4dafaae928b9.jpg)
