### PR TITLE
Refactor Btrieve ordinals

### DIFF
--- a/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
+++ b/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
@@ -580,19 +580,19 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.GetKeyEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.QueryEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
 
-            btrieve.SeekByKey(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
 
-            btrieve.SeekByKey(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
 
-            btrieve.SeekByKey(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
 
-            btrieve.SeekByKey(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(0, Encoding.ASCII.GetBytes("Sysop"), EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
         }
 
@@ -605,37 +605,37 @@ namespace MBBSEmu.Tests.Btrieve
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
             var key = Encoding.ASCII.GetBytes("Sysop");
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             // let's go backwards now
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
             // forward for one last test
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             // back one last time to test in-middle previous
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
         }
 
@@ -648,23 +648,23 @@ namespace MBBSEmu.Tests.Btrieve
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
             var key = Encoding.ASCII.GetBytes("StringValue");
 
-            btrieve.SeekByKey(2, key, EnumBtrieveOperationCodes.GetKeyEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, key, EnumBtrieveOperationCodes.QueryEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
 
-            btrieve.SeekByKey(2, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, key, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, key, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeFalse();
         }
 
         [Fact]
@@ -676,19 +676,19 @@ namespace MBBSEmu.Tests.Btrieve
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
             var key = BitConverter.GetBytes(1052234073);
 
-            btrieve.SeekByKey(1, key, EnumBtrieveOperationCodes.GetKeyEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, key, EnumBtrieveOperationCodes.QueryEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, key, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
 
-            btrieve.SeekByKey(1, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
-            btrieve.SeekByKey(1, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
-            btrieve.SeekByKey(1, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
-            btrieve.SeekByKey(1, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeFalse();
         }
 
         [Fact]
@@ -700,10 +700,10 @@ namespace MBBSEmu.Tests.Btrieve
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
             var key = Encoding.ASCII.GetBytes("Sysop2");
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyEqual, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryEqual).Should().BeFalse();
 
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
-            btrieve.SeekByKey(0, key, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
+            btrieve.PerformOperation(0, key, EnumBtrieveOperationCodes.QueryPrevious).Should().BeFalse();
         }
 
         [Fact]
@@ -714,25 +714,25 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyFirst, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryFirst).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("3444");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryPrevious).Should().BeFalse();
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("7776");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("StringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
         }
 
@@ -744,25 +744,25 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyFirst, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryFirst).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(-615634567);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryPrevious).Should().BeFalse();
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(3444);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(7776);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
         }
 
@@ -776,7 +776,7 @@ namespace MBBSEmu.Tests.Btrieve
 
             btrieve.DeleteAll();
 
-            btrieve.SeekByKey(0, null, EnumBtrieveOperationCodes.GetKeyFirst, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(0, null, EnumBtrieveOperationCodes.QueryFirst).Should().BeFalse();
         }
 
         [Fact]
@@ -787,14 +787,14 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyLast, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryLast).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
         }
 
@@ -806,14 +806,14 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyLast, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryLast).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyPrevious, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryPrevious).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
         }
 
@@ -827,7 +827,7 @@ namespace MBBSEmu.Tests.Btrieve
 
             btrieve.DeleteAll();
 
-            btrieve.SeekByKey(0, null, EnumBtrieveOperationCodes.GetKeyLast, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(0, null, EnumBtrieveOperationCodes.QueryLast).Should().BeFalse();
         }
 
         [Fact]
@@ -838,15 +838,15 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.GetKeyGreater, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.QueryGreater).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("StringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
         }
 
@@ -858,15 +858,15 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(3444), EnumBtrieveOperationCodes.GetKeyGreater, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(3444), EnumBtrieveOperationCodes.QueryGreater).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(7776);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
         }
 
@@ -878,7 +878,7 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(2_000_000_000), EnumBtrieveOperationCodes.GetKeyGreater, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(2_000_000_000), EnumBtrieveOperationCodes.QueryGreater).Should().BeFalse();
         }
 
         [Fact]
@@ -889,19 +889,19 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.GetKeyGreaterOrEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.QueryGreaterOrEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("7776");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("StringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
         }
 
@@ -913,19 +913,19 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(3444), EnumBtrieveOperationCodes.GetKeyGreaterOrEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(3444), EnumBtrieveOperationCodes.QueryGreaterOrEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(3444);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(7776);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
         }
 
@@ -939,7 +939,7 @@ namespace MBBSEmu.Tests.Btrieve
 
             btrieve.DeleteAll();
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(2_000_000_000), EnumBtrieveOperationCodes.GetKeyGreaterOrEqual, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(2_000_000_000), EnumBtrieveOperationCodes.QueryGreaterOrEqual).Should().BeFalse();
         }
 
         [Fact]
@@ -950,23 +950,23 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.GetKeyLess, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.QueryLess).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("3444");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("7776");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("StringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
         }
 
@@ -978,19 +978,19 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(7776), EnumBtrieveOperationCodes.GetKeyLess, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(7776), EnumBtrieveOperationCodes.QueryLess).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(3444);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(7776);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
         }
 
@@ -1002,7 +1002,7 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(-2_000_000_000), EnumBtrieveOperationCodes.GetKeyLess, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(-2_000_000_000), EnumBtrieveOperationCodes.QueryLess).Should().BeFalse();
         }
 
         [Fact]
@@ -1013,19 +1013,19 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.GetKeyLessOrEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(2, Encoding.ASCII.GetBytes("7776"), EnumBtrieveOperationCodes.QueryLessOrEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("7776");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("StringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key2.Should().Be("stringValue");
 
-            btrieve.SeekByKey(2, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(2, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(4);
         }
 
@@ -1037,15 +1037,15 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(7776), EnumBtrieveOperationCodes.GetKeyLessOrEqual, newQuery: true).Should().BeTrue();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(7776), EnumBtrieveOperationCodes.QueryLessOrEqual).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(7776);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeTrue();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeTrue();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord(btrieve.Position)?.Data).Key1.Should().Be(1052234073);
 
-            btrieve.SeekByKey(1, null, EnumBtrieveOperationCodes.GetKeyNext, newQuery: false).Should().BeFalse();
+            btrieve.PerformOperation(1, null, EnumBtrieveOperationCodes.QueryNext).Should().BeFalse();
             btrieve.GetRecord(btrieve.Position)?.Offset.Should().Be(3);
         }
 
@@ -1059,7 +1059,7 @@ namespace MBBSEmu.Tests.Btrieve
 
             btrieve.DeleteAll();
 
-            btrieve.SeekByKey(1, BitConverter.GetBytes(-2_000_000_000), EnumBtrieveOperationCodes.GetKeyLessOrEqual, newQuery: true).Should().BeFalse();
+            btrieve.PerformOperation(1, BitConverter.GetBytes(-2_000_000_000), EnumBtrieveOperationCodes.QueryLessOrEqual).Should().BeFalse();
         }
 
         /// <summary>Creates a copy of data shrunk by cutOff bytes at the end</summary>

--- a/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
+++ b/MBBSEmu.Tests/Btrieve/BtrieveFileProcessor_Tests.cs
@@ -232,23 +232,23 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.StepFirst().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepFirst).Should().BeTrue();
             btrieve.Position.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(3444);
 
-            btrieve.StepNext().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeTrue();
             btrieve.Position.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(7776);
 
-            btrieve.StepNext().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeTrue();
             btrieve.Position.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(1052234073);
 
-            btrieve.StepNext().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeTrue();
             btrieve.Position.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(-615634567);
 
-            btrieve.StepNext().Should().BeFalse();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeFalse();
             btrieve.Position.Should().Be(4);
         }
 
@@ -260,23 +260,23 @@ namespace MBBSEmu.Tests.Btrieve
             var serviceResolver = new ServiceResolver();
             using var btrieve = new BtrieveFileProcessor(serviceResolver.GetService<IFileUtility>(), _modulePath, "MBBSEMU.DAT");
 
-            btrieve.StepLast().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepLast).Should().BeTrue();
             btrieve.Position.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(-615634567);
 
-            btrieve.StepPrevious().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepPrevious).Should().BeTrue();
             btrieve.Position.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(1052234073);
 
-            btrieve.StepPrevious().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepPrevious).Should().BeTrue();
             btrieve.Position.Should().Be(2);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(7776);
 
-            btrieve.StepPrevious().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepPrevious).Should().BeTrue();
             btrieve.Position.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(3444);
 
-            btrieve.StepPrevious().Should().BeFalse();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepPrevious).Should().BeFalse();
             btrieve.Position.Should().Be(1);
         }
 
@@ -384,19 +384,19 @@ namespace MBBSEmu.Tests.Btrieve
 
             btrieve.Delete().Should().BeTrue();
 
-            btrieve.StepFirst().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepFirst).Should().BeTrue();
             btrieve.Position.Should().Be(1);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(3444);
 
-            btrieve.StepNext().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeTrue();
             btrieve.Position.Should().Be(3);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(1052234073);
 
-            btrieve.StepNext().Should().BeTrue();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeTrue();
             btrieve.Position.Should().Be(4);
             new MBBSEmuRecord(btrieve.GetRecord()).Key1.Should().Be(-615634567);
 
-            btrieve.StepNext().Should().BeFalse();
+            btrieve.PerformOperation(-1, ReadOnlySpan<byte>.Empty, EnumBtrieveOperationCodes.StepNext).Should().BeFalse();
         }
 
         [Fact]

--- a/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
+++ b/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
@@ -244,7 +244,7 @@ namespace MBBSEmu.Btrieve
         /// <summary>
         ///     Sets Position to the offset of the first Record in the loaded Btrieve File.
         /// </summary>
-        public bool StepFirst()
+        private bool StepFirst()
         {
             // TODO consider grabbing data at the same time and prepopulating the cache
             using var cmd = new SqliteCommand("SELECT id FROM data_t ORDER BY id LIMIT 1", _connection);
@@ -258,7 +258,7 @@ namespace MBBSEmu.Btrieve
         /// <summary>
         ///     Sets Position to the offset of the next logical Record in the loaded Btrieve File.
         /// </summary>
-        public bool StepNext()
+        private bool StepNext()
         {
             // TODO consider grabbing data at the same time and prepopulating the cache
             using var cmd = new SqliteCommand($"SELECT id FROM data_t WHERE id > {Position} ORDER BY id LIMIT 1;", _connection);
@@ -280,7 +280,7 @@ namespace MBBSEmu.Btrieve
         /// <summary>
         ///     Sets Position to the offset of the previous logical record in the loaded Btrieve File.
         /// </summary>
-        public bool StepPrevious()
+        private bool StepPrevious()
         {
             using var cmd = new SqliteCommand($"SELECT id FROM data_t WHERE id < {Position} ORDER BY id DESC LIMIT 1;",
                 _connection);
@@ -302,7 +302,7 @@ namespace MBBSEmu.Btrieve
         /// <summary>
         ///     Sets Position to the offset of the last Record in the loaded Btrieve File.
         /// </summary>
-        public bool StepLast()
+        private bool StepLast()
         {
             // TODO consider grabbing data at the same time and prepopulating the cache
             using var cmd = new SqliteCommand("SELECT id FROM data_t ORDER BY id DESC LIMIT 1;", _connection);

--- a/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
+++ b/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
@@ -595,11 +595,6 @@ namespace MBBSEmu.Btrieve
                     KeyData = key == null ? null : new byte[key.Length],
                 };
 
-                /*
-                 * TODO -- It appears MajorBBS/WG don't respect the Btrieve length for the key, as it's just part of a struct.
-                 * There are modules that define in their btrieve file a STRING key of length 1, but pass in a char*
-                 * So for the time being, we just make the key length we're looking for whatever was passed in.
-                 */
                 if (key != null)
                 {
                     Array.Copy(key.ToArray(), 0, currentQuery.KeyData, 0, key.Length);

--- a/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
+++ b/MBBSEmu/Btrieve/BtrieveFileProcessor.cs
@@ -639,7 +639,10 @@ namespace MBBSEmu.Btrieve
                 EnumBtrieveOperationCodes.AcquireLessOrEqual => GetByKeyLess(currentQuery, "<="),
                 EnumBtrieveOperationCodes.QueryLessOrEqual => GetByKeyLess(currentQuery, "<="),
 
+                EnumBtrieveOperationCodes.AcquireNext => GetByKeyNext(currentQuery),
                 EnumBtrieveOperationCodes.QueryNext => GetByKeyNext(currentQuery),
+
+                EnumBtrieveOperationCodes.AcquirePrevious => GetByKeyPrevious(currentQuery),
                 EnumBtrieveOperationCodes.QueryPrevious => GetByKeyPrevious(currentQuery),
 
                 _ => throw new Exception($"Unsupported Operation Code: {btrieveOperationCode}")

--- a/MBBSEmu/Btrieve/Enums/EnumBtrieveOperationCodes.cs
+++ b/MBBSEmu/Btrieve/Enums/EnumBtrieveOperationCodes.cs
@@ -122,7 +122,7 @@
         public static bool UsesPreviousQuery(this EnumBtrieveOperationCodes code)
         {
             var memberInstance = code.GetType().GetMember(code.ToString());
-            if (memberInstance == null || memberInstance.Length <= 0) return false;
+            if (memberInstance.Length <= 0) return false;
 
             return System.Attribute.GetCustomAttribute(memberInstance[0], typeof(UsesPreviousQuery)) != null;
         }
@@ -130,7 +130,7 @@
         public static bool AcquiresData(this EnumBtrieveOperationCodes code)
         {
             var memberInstance = code.GetType().GetMember(code.ToString());
-            if (memberInstance == null || memberInstance.Length <= 0) return false;
+            if (memberInstance.Length <= 0) return false;
 
             return System.Attribute.GetCustomAttribute(memberInstance[0], typeof(AcquiresData)) != null;
         }

--- a/MBBSEmu/Btrieve/Enums/EnumBtrieveOperationCodes.cs
+++ b/MBBSEmu/Btrieve/Enums/EnumBtrieveOperationCodes.cs
@@ -1,11 +1,20 @@
 ﻿namespace MBBSEmu.Btrieve.Enums
 {
+    /// <summary>
+    ///     Specifies whether the operation code operates on a previous query.
+    /// </summary>
     [System.AttributeUsage(System.AttributeTargets.Field)]
     public class UsesPreviousQuery : System.Attribute {}
 
+    /// <summary>
+    ///     Specifies whether the operation code results in data being acquired.
+    /// </summary>
     [System.AttributeUsage(System.AttributeTargets.Field)]
     public class AcquiresData : System.Attribute {}
 
+    /// <summary>
+    ///     Specifies whether the operation code results in key data being queried.
+    /// </summary>
     [System.AttributeUsage(System.AttributeTargets.Field)]
     public class QueryOnly : System.Attribute {}
 
@@ -21,22 +30,30 @@
         // Acquire Operations
         [AcquiresData]
         AcquireEqual = 0x5,
+
         [AcquiresData]
         [UsesPreviousQuery]
         AcquireNext = 0x6,
+
         [AcquiresData]
         [UsesPreviousQuery]
         AcquirePrevious = 0x7,
+
         [AcquiresData]
         AcquireGreater = 0x8,
+
         [AcquiresData]
         AcquireGreaterOrEqual = 0x9,
+
         [AcquiresData]
         AcquireLess = 0xA,
+
         [AcquiresData]
         AcquireLessOrEqual = 0xB,
+
         [AcquiresData]
         AcquireFirst = 0xC,
+
         [AcquiresData]
         AcquireLast = 0xD,
 
@@ -47,18 +64,22 @@
         // Step Operations, operates on physical offset not keys
         [AcquiresData]
         StepFirst = 0x21,
+
         [AcquiresData]
         StepLast = 0x22,
+
         [AcquiresData]
         [UsesPreviousQuery]
         StepNext = 0x18,
+
         [AcquiresData]
         [UsesPreviousQuery]
-
         StepNextExtended = 0x26,
+
         [AcquiresData]
         [UsesPreviousQuery]
         StepPrevious = 0x23,
+
         [AcquiresData]
         [UsesPreviousQuery]
         StepPreviousExtended = 0x27,
@@ -66,22 +87,30 @@
         // Query Operations
         [QueryOnly]
         QueryEqual = 0x37,
+
         [QueryOnly]
         [UsesPreviousQuery]
         QueryNext = 0x38,
+
         [QueryOnly]
         [UsesPreviousQuery]
         QueryPrevious = 0x39,
+
         [QueryOnly]
         QueryGreater = 0x3A,
+
         [QueryOnly]
         QueryGreaterOrEqual = 0x3B,
+
         [QueryOnly]
         QueryLess = 0x3C,
+
         [QueryOnly]
         QueryLessOrEqual = 0x3D,
+
         [QueryOnly]
         QueryFirst = 0x3E,
+
         [QueryOnly]
         QueryLast = 0x3F,
 

--- a/MBBSEmu/Btrieve/Enums/EnumBtrieveOperationCodes.cs
+++ b/MBBSEmu/Btrieve/Enums/EnumBtrieveOperationCodes.cs
@@ -1,48 +1,109 @@
 ﻿namespace MBBSEmu.Btrieve.Enums
 {
+    [System.AttributeUsage(System.AttributeTargets.Field)]
+    public class UsesPreviousQuery : System.Attribute {}
+
+    [System.AttributeUsage(System.AttributeTargets.Field)]
+    public class AcquiresData : System.Attribute {}
+
+    [System.AttributeUsage(System.AttributeTargets.Field)]
+    public class QueryOnly : System.Attribute {}
+
     /// <summary>
     ///     Btrieve Operation Codes that are passed into Btrieve
     /// </summary>
     public enum EnumBtrieveOperationCodes : ushort
     {
-        //Utility
+        // Utility
         Open = 0x0,
         Close = 0x1,
 
-        //Get Operations
-        GetEqual = 0x5,
-        GetNext = 0x6,
-        GetPrevious = 0x7,
-        GetGreater = 0x8,
-        GetGreaterOrEqual = 0x9,
-        GetLess = 0xA,
-        GetLessOrEqual = 0xB,
-        GetFirst = 0xC,
-        GetLast = 0xD,
+        // Acquire Operations
+        [AcquiresData]
+        AcquireEqual = 0x5,
+        [AcquiresData]
+        [UsesPreviousQuery]
+        AcquireNext = 0x6,
+        [AcquiresData]
+        [UsesPreviousQuery]
+        AcquirePrevious = 0x7,
+        [AcquiresData]
+        AcquireGreater = 0x8,
+        [AcquiresData]
+        AcquireGreaterOrEqual = 0x9,
+        [AcquiresData]
+        AcquireLess = 0xA,
+        [AcquiresData]
+        AcquireLessOrEqual = 0xB,
+        [AcquiresData]
+        AcquireFirst = 0xC,
+        [AcquiresData]
+        AcquireLast = 0xD,
 
-        //Information Operations
+        // Information Operations
         Stat = 0xF,
         SetOwner = 0x1D,
 
-        //Step Operations
+        // Step Operations, operates on physical offset not keys
+        [AcquiresData]
         StepFirst = 0x21,
+        [AcquiresData]
         StepLast = 0x22,
+        [AcquiresData]
+        [UsesPreviousQuery]
         StepNext = 0x18,
+        [AcquiresData]
+        [UsesPreviousQuery]
+
         StepNextExtended = 0x26,
+        [AcquiresData]
+        [UsesPreviousQuery]
         StepPrevious = 0x23,
+        [AcquiresData]
+        [UsesPreviousQuery]
         StepPreviousExtended = 0x27,
 
-        //Get Key Operations
-        GetKeyEqual = 0x37,
-        GetKeyNext = 0x38,
-        GetKeyPrevious = 0x39,
-        GetKeyGreater = 0x3A,
-        GetKeyGreaterOrEqual = 0x3B,
-        GetKeyLess = 0x3C,
-        GetKeyLessOrEqual = 0x3D,
-        GetKeyFirst = 0x3E,
-        GetKeyLast = 0x3F,
+        // Query Operations
+        [QueryOnly]
+        QueryEqual = 0x37,
+        [QueryOnly]
+        [UsesPreviousQuery]
+        QueryNext = 0x38,
+        [QueryOnly]
+        [UsesPreviousQuery]
+        QueryPrevious = 0x39,
+        [QueryOnly]
+        QueryGreater = 0x3A,
+        [QueryOnly]
+        QueryGreaterOrEqual = 0x3B,
+        [QueryOnly]
+        QueryLess = 0x3C,
+        [QueryOnly]
+        QueryLessOrEqual = 0x3D,
+        [QueryOnly]
+        QueryFirst = 0x3E,
+        [QueryOnly]
+        QueryLast = 0x3F,
 
         None = ushort.MaxValue
+    }
+
+    public static class Extensions
+    {
+        public static bool UsesPreviousQuery(this EnumBtrieveOperationCodes code)
+        {
+            var memberInstance = code.GetType().GetMember(code.ToString());
+            if (memberInstance == null || memberInstance.Length <= 0) return false;
+
+            return System.Attribute.GetCustomAttribute(memberInstance[0], typeof(UsesPreviousQuery)) != null;
+        }
+
+        public static bool AcquiresData(this EnumBtrieveOperationCodes code)
+        {
+            var memberInstance = code.GetType().GetMember(code.ToString());
+            if (memberInstance == null || memberInstance.Length <= 0) return false;
+
+            return System.Attribute.GetCustomAttribute(memberInstance[0], typeof(AcquiresData)) != null;
+        }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -2356,21 +2356,23 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 return false;
 
             if (!destinationRecordBuffer.Equals(IntPtr16.Empty))
-            {
                 Module.Memory.SetArray(destinationRecordBuffer,record.Data);
-            }
 
             var bbPointer = Module.Memory.GetPointer("BB");
             var btvStruct = new BtvFileStruct(Module.Memory.GetArray(bbPointer, BtvFileStruct.Size));
-            if (keyNumber > 0)
+            if (keyNumber >= 0)
             {
                 btvStruct.lastkn = (ushort)keyNumber;
                 Module.Memory.SetArray(bbPointer, btvStruct.Data);
             }
+            else
+            {
+                keyNumber = (short)btvStruct.lastkn;
+            }
 
             Module.Memory.SetArray(btvStruct.data, record.Data);
 
-            if (keyNumber > 0)
+            if (keyNumber >= 0)
                 Module.Memory.SetArray(btvStruct.key, currentBtrieveFile.Keys[(ushort)keyNumber].ExtractKeyDataFromRecord(record.Data));
 
             return true;
@@ -4930,8 +4932,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var currentBtrieveFile = BtrieveGetProcessor(Module.Memory.GetPointer("BB"));
 
-            var record = currentBtrieveFile.GetRecordByOffset((uint)absolutePosition);
-
             UpdateBB(currentBtrieveFile, recordPointer, (uint)absolutePosition, (short)keynum);
         }
 
@@ -5711,9 +5711,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //Set Record Pointer to Result
             if (result)
             {
-                var btvStruct = new BtvFileStruct(Module.Memory.GetArray(Module.Memory.GetPointer("BB"), BtvFileStruct.Size));
-
-                UpdateBB(currentBtrieveFile, IntPtr16.Empty, btvStruct.lastkn);
+                UpdateBB(currentBtrieveFile, IntPtr16.Empty, -1);
             }
 
             Registers.AX = result ? (ushort)1 : (ushort)0;


### PR DESCRIPTION
Created a new method `PerformOperation` which basically handles any `EnumBtrieveOperationCode`

`UpdateBB` method in `Majorbbs.cs` handles the updating of the BB struct and eliminates all the code duplication.