### PR TITLE
Issue 286

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/FileTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/FileTestBase.cs
@@ -87,37 +87,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs {
             fprintfParameters.Add(inputStingParameterPointer.Segment);
 
             //Add Parameters
-            foreach (var v in values)
-            {
-                switch (v)
-                {
-                    case string @parameterString:
-                    {
-                        var stringParameterPointer = mbbsEmuMemoryCore.AllocateVariable(Guid.NewGuid().ToString(), (ushort)(@parameterString.Length + 1));
-                        mbbsEmuMemoryCore.SetArray(stringParameterPointer, Encoding.ASCII.GetBytes(@parameterString));
-                        fprintfParameters.Add(stringParameterPointer.Offset);
-                        fprintfParameters.Add(stringParameterPointer.Segment);
-                        break;
-                    }
-                    case uint @parameterULong:
-                    {
-                        var longBytes = BitConverter.GetBytes(@parameterULong);
-                        fprintfParameters.Add(BitConverter.ToUInt16(longBytes, 0));
-                        fprintfParameters.Add(BitConverter.ToUInt16(longBytes, 2));
-                        break;
-                    }
-                    case int @parameterLong:
-                    {
-                        var longBytes = BitConverter.GetBytes(@parameterLong);
-                        fprintfParameters.Add(BitConverter.ToUInt16(longBytes, 0));
-                        fprintfParameters.Add(BitConverter.ToUInt16(longBytes, 2));
-                        break;
-                    }
-                    case ushort @parameterInt:
-                        fprintfParameters.Add(@parameterInt);
-                        break;
-                }
-            }
+            var parameterList = GenerateParameters(values);
+            fprintfParameters.AddRange(parameterList);
 
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, FPRINTF_ORDINAL, fprintfParameters);
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
@@ -246,6 +246,26 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(elementSize * numElements, new FileInfo(Path.Join(mbbsModule.ModulePath, "FILE.TXT")).Length);
         }
 
+        [Fact]
+        public void fopen_write_fprintf_new_file()
+        {
+            //Reset State
+            Reset();
+            
+            var filep = fopen("FILE.TXT", "w");
+            Assert.NotEqual(0, filep.Segment);
+            Assert.NotEqual(0, filep.Offset);
+
+            var controlString = "%s";
+            var numberOfCharacters = 100;
+
+            Assert.Equal(numberOfCharacters, f_printf(filep, controlString, LOREM_IPSUM.Substring(0, numberOfCharacters)));
+
+            Assert.Equal(0, fclose(filep));
+
+            Assert.Equal(numberOfCharacters, new FileInfo(Path.Join(mbbsModule.ModulePath, "FILE.TXT")).Length);
+        }
+
         [Theory]
         [InlineData("a")]
         [InlineData("a+")]

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/file_Tests.cs
@@ -1,5 +1,4 @@
 using MBBSEmu.Memory;
-using NLog;
 using System;
 using System.IO;
 using System.Text;

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
@@ -13,6 +13,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
         private const ushort HASKEY_ORDINAL = 334;
         private const ushort HASMKEY_ORDINAL = 335;
+        private const ushort UIDKEY_ORDINAL = 609;
 
         [Fact]
         public void haskey_Test()
@@ -94,6 +95,29 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASKEY_ORDINAL, new List<IntPtr16> { stringPointer });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void uidkey_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            var username = "guest";
+            var key = "NORMAL";
+
+            //Set Argument Values to be Passed In
+            var usernamePointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(username.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(username));
+            var keyPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING2", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING2", Encoding.ASCII.GetBytes(key));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, UIDKEY_ORDINAL, new List<IntPtr16> { usernamePointer, keyPointer });
 
             Assert.Equal(1, mbbsEmuCpuRegisters.AX);
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
@@ -100,15 +100,38 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
         }
 
-        [Fact]
-        public void uidkey_Test()
+        [Theory]
+        [InlineData("guest", "NORMAL", 1)]
+        [InlineData("guest", "DERP", 0)]
+        [InlineData("derp", "NORMAL", 1)]
+        [InlineData("guest", "", 1)]
+        public void uidkey_Test(string username, string key, ushort expectedResult)
         {
             //Reset State
             Reset();
 
-            //Set the test Username
+            //Set Argument Values to be Passed In
+            var usernamePointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(username.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes(username));
+            var keyPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING2", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING2", Encoding.ASCII.GetBytes(key));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, UIDKEY_ORDINAL, new List<IntPtr16> { usernamePointer, keyPointer });
+
+            Assert.Equal(expectedResult, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void uidkey_Custom_Test()
+        {
+            //Reset State
+            Reset();
+
+            _serviceResolver.GetService<IAccountKeyRepository>().InsertAccountKeyByUsername("guest", "DERP");
             var username = "guest";
-            var key = "NORMAL";
+            var key = "DERP";
 
             //Set Argument Values to be Passed In
             var usernamePointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(username.Length + 1));

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
@@ -35,37 +35,9 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             parameters.Add(inputStingParameterPointer.Offset);
             parameters.Add(inputStingParameterPointer.Segment);
 
-            foreach (var v in values)
-            {
-                switch (v)
-                {
-                    case string @parameterString:
-                    {
-                        var stringParameterPointer = mbbsEmuMemoryCore.AllocateVariable(Guid.NewGuid().ToString(), (ushort)(@parameterString.Length + 1));
-                        mbbsEmuMemoryCore.SetArray(stringParameterPointer, Encoding.ASCII.GetBytes(@parameterString));
-                        parameters.Add(stringParameterPointer.Offset);
-                        parameters.Add(stringParameterPointer.Segment);
-                        break;
-                    }
-                    case uint @parameterULong:
-                    {
-                        var longBytes = BitConverter.GetBytes(@parameterULong);
-                        parameters.Add(BitConverter.ToUInt16(longBytes, 0));
-                        parameters.Add(BitConverter.ToUInt16(longBytes, 2));
-                        break;
-                    }
-                    case int @parameterLong:
-                    {
-                        var longBytes = BitConverter.GetBytes(@parameterLong);
-                        parameters.Add(BitConverter.ToUInt16(longBytes, 0));
-                        parameters.Add(BitConverter.ToUInt16(longBytes, 2));
-                        break;
-                    }
-                    case ushort @parameterInt:
-                        parameters.Add(@parameterInt);
-                        break;
-                }
-            }
+            var parameterList = GenerateParameters(values);
+            foreach (var p in parameterList)
+                parameters.Add(p);
 
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, PRF_ORDINAL, parameters);
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3865,7 +3865,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             if (!FilePointerDictionary.TryGetValue(fileStruct.curp.Offset, out var fileStream))
                 throw new Exception($"Unable to locate FileStream for {fileStructPointer} (Stream: {fileStruct.curp})");
 
-            var output = Module.Memory.GetString(sourcePointer);
+            var output = Module.Memory.GetString(sourcePointer, true);
 
             //If the supplied string has any control characters for formatting, process them
             var formattedMessage = FormatPrintf(output, 4);

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -124,7 +124,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.AllocateVariable("OTHUAP", 0x04, true); //Pointer to OTHER user
             Module.Memory.AllocateVariable("OTHEXP", 0x04, true); //Pointer to OTHER user
             var ntermsPointer = Module.Memory.AllocateVariable("NTERMS", 0x2); //ushort number of lines
-            Module.Memory.SetWord(ntermsPointer, (ushort) _numberOfChannels); // Number of channels from Settings
+            Module.Memory.SetWord(ntermsPointer, (ushort)_numberOfChannels); // Number of channels from Settings
 
             Module.Memory.AllocateVariable("OTHUSN", 0x2); //Set by onsys() or instat()
             Module.Memory.AllocateVariable("OTHUSP", 0x4, true);
@@ -2371,7 +2371,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             {
                 Module.Memory.SetArray(btvStruct.data, record.Data);
                 if (!destinationRecordBuffer.Equals(IntPtr16.Empty))
-                    Module.Memory.SetArray(destinationRecordBuffer,record.Data);
+                    Module.Memory.SetArray(destinationRecordBuffer, record.Data);
             }
 
             if (keyNumber >= 0)
@@ -2466,7 +2466,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var btrieveRecordPointer = GetParameterPointer(0);
 
             var currentBtrieveFile = BtrieveGetProcessor(Module.Memory.GetPointer("BB"));
-            var dataToWrite = Module.Memory.GetArray(btrieveRecordPointer, (ushort) currentBtrieveFile.RecordLength);
+            var dataToWrite = Module.Memory.GetArray(btrieveRecordPointer, (ushort)currentBtrieveFile.RecordLength);
 
             return currentBtrieveFile.Insert(dataToWrite.ToArray()) != 0;
         }
@@ -3882,6 +3882,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
 #if DEBUG
             _logger.Info($"Wrote {formattedMessage.Length} bytes to {fileStructPointer} (Stream: {fileStruct.curp})");
 #endif
+
+            Registers.AX = (ushort)formattedMessage.Length;
         }
 
         /// <summary>
@@ -5601,7 +5603,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         private void qnpbtv()
         {
-            var queryOption = (EnumBtrieveOperationCodes) GetParameter(0);
+            var queryOption = (EnumBtrieveOperationCodes)GetParameter(0);
 
             var currentBtrieveFile = BtrieveGetProcessor(Module.Memory.GetPointer("BB"));
             var result = currentBtrieveFile.PerformOperation(currentBtrieveFile.PreviousQuery.Key.Number, currentBtrieveFile.PreviousQuery.KeyData, queryOption);
@@ -5891,7 +5893,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 if (char.IsUpper((char)inputString[i]))
                     inputString[i] = (byte)char.ToLower((char)inputString[i]);
 
-                if (inputString[i] == (byte) ' ')
+                if (inputString[i] == (byte)' ')
                     isSpace = true;
 
                 if (char.IsLower((char)inputString[i]) && isSpace)
@@ -7001,8 +7003,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 keys = accountKeys.Select(x => x.accountKey);
             }
 
-            Registers.AX = (ushort) (keys.Any(k =>
-                string.Equals(accountLock, k, StringComparison.InvariantCultureIgnoreCase))
+            Registers.AX = (ushort)(keys.Any(k =>
+               string.Equals(accountLock, k, StringComparison.InvariantCultureIgnoreCase))
                 ? 1
                 : 0);
 #if DEBUG


### PR DESCRIPTION
- Added Implementation of `uidkey()`
- Fixed `f_printf()` to not write the null terminator of the string being written to the file stream
- Fixed `f_printf()` to return the number of bytes written
- Unit Tests for Both

Fixes #286 