### PR TITLE
Stack and module fixes

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/register_module_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/register_module_Tests.cs
@@ -45,6 +45,24 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             Assert.Equal(new IntPtr16(0x0008, 0x0008), mbbsModule.EntryPoints["mcurou"]);
             Assert.Equal(new IntPtr16(0x0009, 0x0009), mbbsModule.EntryPoints["stsrou"]);
             Assert.NotEqual(IntPtr16.Empty, mbbsEmuMemoryCore.GetPointer(mbbsEmuMemoryCore.GetVariablePointer("MODULE") + (2 * mbbsModule.StateCode)));
+
+            //Verify the Local Copy
+            var localModulePointer =
+                mbbsEmuMemoryCore.GetPointer(
+                    mbbsEmuMemoryCore.GetVariablePointer("MODULE") + (2 * mbbsModule.StateCode));
+
+            var localModuleStruct = new ModuleStruct(mbbsEmuMemoryCore.GetArray(localModulePointer, ModuleStruct.Size));
+
+            Assert.Equal(Encoding.ASCII.GetString(moduleStruct.descrp).TrimEnd('\0'), Encoding.ASCII.GetString(localModuleStruct.descrp).TrimEnd('\0'));
+            Assert.Equal(new IntPtr16(0x0001, 0x0001), localModuleStruct.sttrou);
+            Assert.Equal(new IntPtr16(0x0002, 0x0002), localModuleStruct.dlarou);
+            Assert.Equal(new IntPtr16(0x0003, 0x0003), localModuleStruct.finrou);
+            Assert.Equal(new IntPtr16(0x0004, 0x0004), localModuleStruct.huprou);
+            Assert.Equal(new IntPtr16(0x0005, 0x0005), localModuleStruct.injrou);
+            Assert.Equal(new IntPtr16(0x0006, 0x0006), localModuleStruct.lofrou);
+            Assert.Equal(new IntPtr16(0x0007, 0x0007), localModuleStruct.lonrou);
+            Assert.Equal(new IntPtr16(0x0008, 0x0008), localModuleStruct.mcurou);
+            Assert.Equal(new IntPtr16(0x0009, 0x0009), localModuleStruct.stsrou);
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/register_module_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/register_module_Tests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using MBBSEmu.HostProcess.Structs;
+using MBBSEmu.Memory;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class register_module_Tests : ExportedModuleTestBase
+    {
+        private const int REGISTER_MODULE_ORDINAL = 492;
+
+        [Fact]
+        public void register_module_test()
+        {
+            var moduleStruct = new ModuleStruct
+            {
+                descrp = Encoding.ASCII.GetBytes("Test Module\0"),
+                sttrou = new IntPtr16(0x0001, 0x0001),
+                dlarou = new IntPtr16(0x0002, 0x0002),
+                finrou = new IntPtr16(0x0003, 0x0003),
+                huprou = new IntPtr16(0x0004, 0x0004),
+                injrou = new IntPtr16(0x0005, 0x0005),
+                lofrou = new IntPtr16(0x0006, 0x0006),
+                lonrou = new IntPtr16(0x0007, 0x0007),
+                mcurou = new IntPtr16(0x0008, 0x0008),
+                stsrou = new IntPtr16(0x0009, 0x0009)
+            };
+
+            var modulePointer = mbbsEmuMemoryCore.AllocateVariable("MODULE", ModuleStruct.Size);
+            mbbsEmuMemoryCore.SetArray(modulePointer, moduleStruct.Data);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, REGISTER_MODULE_ORDINAL, new List<IntPtr16> { modulePointer });
+
+            Assert.Equal(Encoding.ASCII.GetString(moduleStruct.descrp).TrimEnd('\0'), mbbsModule.ModuleDescription);
+            Assert.Equal(new IntPtr16(0x0001, 0x0001), mbbsModule.EntryPoints["sttrou"]);
+            Assert.Equal(new IntPtr16(0x0002, 0x0002), mbbsModule.EntryPoints["dlarou"]);
+            Assert.Equal(new IntPtr16(0x0003, 0x0003), mbbsModule.EntryPoints["finrou"]);
+            Assert.Equal(new IntPtr16(0x0004, 0x0004), mbbsModule.EntryPoints["huprou"]);
+            Assert.Equal(new IntPtr16(0x0005, 0x0005), mbbsModule.EntryPoints["injrou"]);
+            Assert.Equal(new IntPtr16(0x0006, 0x0006), mbbsModule.EntryPoints["lofrou"]);
+            Assert.Equal(new IntPtr16(0x0007, 0x0007), mbbsModule.EntryPoints["lonrou"]);
+            Assert.Equal(new IntPtr16(0x0008, 0x0008), mbbsModule.EntryPoints["mcurou"]);
+            Assert.Equal(new IntPtr16(0x0009, 0x0009), mbbsModule.EntryPoints["stsrou"]);
+            Assert.NotEqual(IntPtr16.Empty, mbbsEmuMemoryCore.GetPointer(mbbsEmuMemoryCore.GetVariablePointer("MODULE") + (2 * mbbsModule.StateCode)));
+        }
+    }
+}

--- a/MBBSEmu/CPU/CPUCore.cs
+++ b/MBBSEmu/CPU/CPUCore.cs
@@ -76,7 +76,7 @@ namespace MBBSEmu.CPU
         /// <summary>
         ///     Default Value for the SP Register (Stack Pointer)
         /// </summary>
-        public const ushort STACK_BASE = 0xFFFF;
+        public const ushort STACK_BASE = 0xFFFE;
 
         /// <summary>
         ///     Default Segment for the Stack in Memory

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -418,8 +418,17 @@ namespace MBBSEmu.HostProcess.ExportedModules
                                 if (isVsPrintf)
                                 {
                                     var stringPointer = Module.Memory.GetPointer(vsPrintfBase);
-                                    parameter = Module.Memory.GetString(stringPointer);
-                                    vsPrintfBase.Offset += 4;
+
+                                    if (Module.Memory.HasSegment(stringPointer.Segment))
+                                    {
+                                        parameter = Module.Memory.GetString(stringPointer);
+                                        vsPrintfBase.Offset += 4;
+                                    }
+                                    else
+                                    {
+                                        parameter = Encoding.ASCII.GetBytes("Invalid Pointer");
+                                        _logger.Error($"Invalid Pointer: {stringPointer}");
+                                    }
                                 }
                                 else
                                 {

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -1404,6 +1404,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var moduleStruct = new ModuleStruct(Module.Memory.GetArray(destinationPointer, ModuleStruct.Size));
 
+            //We create a copy in Variable Memory in case the MODULE pointer that was passed in was on the stack
+            var localModuleStructPointer = Module.Memory.AllocateVariable("MODULE-LOCAL", ModuleStruct.Size);
+            Module.Memory.SetArray("MODULE-LOCAL", moduleStruct.Data);
+
             //Set Module Values from Struct
             Module.ModuleDescription = Encoding.ASCII.GetString(moduleStruct.descrp).TrimEnd('\0');
             Module.EntryPoints.Add("lonrou", moduleStruct.lonrou);
@@ -1419,10 +1423,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
             //usrptr->state is the Module Number in use, as assigned by the host process
             Registers.AX = (ushort)Module.StateCode;
 
-            Module.Memory.SetPointer(Module.Memory.GetVariablePointer("MODULE") + (Module.StateCode *2), destinationPointer);
+            Module.Memory.SetPointer(Module.Memory.GetVariablePointer("MODULE") + (Module.StateCode *2), localModuleStructPointer);
 
 #if DEBUG
-            _logger.Info($"MODULE pointer ({Module.Memory.GetVariablePointer("MODULE") + (Module.StateCode * 2)}) set to {destinationPointer}");
+            _logger.Info($"MODULE pointer ({Module.Memory.GetVariablePointer("MODULE") + (Module.StateCode * 2)}) set to {localModuleStructPointer}");
             _logger.Info($"Module Description set to {Module.ModuleDescription}");
 #endif
 

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -768,7 +768,7 @@ namespace MBBSEmu.HostProcess
             module.ExportedModuleDictionary.Add(Doscalls.Segment, GetFunctions(module, "DOSCALLS"));
 
             //Add it to the Module Dictionary
-            module.StateCode = (short)(_modules.Count + 1);
+            module.StateCode = (short)_modules.Count;
             _modules[module.ModuleIdentifier] = module;
 
             //Run INIT

--- a/MBBSEmu/HostProcess/Structs/ModuleStruct.cs
+++ b/MBBSEmu/HostProcess/Structs/ModuleStruct.cs
@@ -1,0 +1,78 @@
+﻿using MBBSEmu.Memory;
+using System;
+
+namespace MBBSEmu.HostProcess.Structs
+{
+    /// <summary>
+    ///     Struct used to define entry points for a MajorBBS/Worldgroup Module
+    /// </summary>
+    public class ModuleStruct
+    {
+        public byte[] descrp;
+        public IntPtr16 lonrou { get; set; }
+        public IntPtr16 sttrou { get; set; }
+        public IntPtr16 stsrou { get; set; }
+        public IntPtr16 injrou { get; set; }
+        public IntPtr16 lofrou { get; set; }
+        public IntPtr16 huprou { get; set; }
+        public IntPtr16 mcurou { get; set; }
+        public IntPtr16 dlarou { get; set; }
+        public IntPtr16 finrou { get; set; }
+
+        public const ushort Size = 61;
+
+        private readonly byte[] _data = new byte[Size];
+
+        public byte[] Data
+        {
+            get
+            {
+                
+                Array.Copy(descrp, 0, _data, 0, descrp.Length);
+                Array.Copy(lonrou.Data, 0, _data, 25, IntPtr16.Size);
+                Array.Copy(sttrou.Data, 0, _data, 29, IntPtr16.Size);
+                Array.Copy(stsrou.Data, 0, _data, 33, IntPtr16.Size);
+                Array.Copy(injrou.Data, 0, _data, 37, IntPtr16.Size);
+                Array.Copy(lofrou.Data, 0, _data, 41, IntPtr16.Size);
+                Array.Copy(huprou.Data, 0, _data, 45, IntPtr16.Size);
+                Array.Copy(mcurou.Data, 0, _data, 49, IntPtr16.Size);
+                Array.Copy(dlarou.Data, 0, _data, 53, IntPtr16.Size);
+                Array.Copy(finrou.Data, 0, _data, 57, IntPtr16.Size);
+                return _data;
+            }
+            set
+            {
+                var valueSpan = new ReadOnlySpan<byte>(value);
+                descrp = valueSpan.Slice(0, 25).ToArray();
+                lonrou.FromSpan(valueSpan.Slice(25, IntPtr16.Size));
+                sttrou.FromSpan(valueSpan.Slice(29, IntPtr16.Size));
+                stsrou.FromSpan(valueSpan.Slice(33, IntPtr16.Size));
+                injrou.FromSpan(valueSpan.Slice(37, IntPtr16.Size));
+                lofrou.FromSpan(valueSpan.Slice(41, IntPtr16.Size));
+                huprou.FromSpan(valueSpan.Slice(45, IntPtr16.Size));
+                mcurou.FromSpan(valueSpan.Slice(49, IntPtr16.Size));
+                dlarou.FromSpan(valueSpan.Slice(53, IntPtr16.Size));
+                finrou.FromSpan(valueSpan.Slice(57, IntPtr16.Size));
+            }
+        }
+
+        public ModuleStruct()
+        {
+            descrp = new byte[25];
+            lonrou = new IntPtr16();
+            sttrou = new IntPtr16();
+            stsrou = new IntPtr16();
+            injrou = new IntPtr16();
+            lofrou = new IntPtr16();
+            huprou = new IntPtr16();
+            mcurou = new IntPtr16();
+            dlarou = new IntPtr16();
+            finrou = new IntPtr16();
+        }
+
+        public ModuleStruct(ReadOnlySpan<byte> data) : this()
+        {
+            Data = data.ToArray();
+        }
+    }
+}

--- a/MBBSEmu/Module/MBBSModule.cs
+++ b/MBBSEmu/Module/MBBSModule.cs
@@ -48,7 +48,7 @@ namespace MBBSEmu.Module
         /// <summary>
         ///     Menu Option Key of Module
         /// </summary>
-        public string MenuOptionKey;
+        public string MenuOptionKey { get; set; }
 
         /// <summary>
         ///     Module DLL

--- a/MBBSEmu/modules.json
+++ b/MBBSEmu/modules.json
@@ -1,8 +1,8 @@
 {
   "Modules": [
     {
-      "Identifier": "HVSXROAD",
-      "Path": "c:\\dos\\modules\\xroads100k\\"
+      "Identifier": "LOGCAS",
+      "Path": "c:\\dos\\modules\\casino\\"
     }
   ]
 }


### PR DESCRIPTION
Miscellaneous fixes around Logicom Casino

- Not clearing input during `SetState()` and only resetting `nxtcmd` pointer. This was clearing valid input if `curuser` was called during an `sttrou` execution. Because `input` is set during `Status == 3` (input received), this should be fine
- Simplified `register_module` and defined an actual struct for the Module data
- Unit Tests for `register_module`
- Modified the `Module` variable to allow up to 255 module pointers. We **_MIGHT_** need to have this globally somehow, as one module might want to look up the name of another. In the case of Logicom Casino, it was using the struct to get the name of the module on startup for a `vsprintf` function (I imagine it was a re-used Logicom routine). Because of this....
- Module StateCode's must start at zero (not 1). Modified the MenuKey logic to reflect this
- Minor cleanup in `vsprintf`
- Invalid Pointer checking in `%s` vsprintf routine
- Minor Cleanup in Variable Declaration (`IntPtr16.Size` vs. `0x4`)