### PR TITLE
Fix extra chars in buffer from leaking into module

### DIFF
--- a/MBBSEmu.Tests/Integration/MBBSEmuIntegrationTestBase.cs
+++ b/MBBSEmu.Tests/Integration/MBBSEmuIntegrationTestBase.cs
@@ -79,7 +79,7 @@ namespace MBBSEmu.Tests.Integration
             var host = _serviceResolver.GetService<IMbbsHost>();
             var moduleConfigurations = new List<ModuleConfiguration>
             {
-                new ModuleConfiguration {ModuleIdentifier = "MBBSEMU", ModulePath = _modulePath, MenuOptionKey = null}
+                new ModuleConfiguration {ModuleIdentifier = "MBBSEMU", ModulePath = _modulePath, MenuOptionKey = "A"}
             };
 
             host.Start(moduleConfigurations);

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -1429,8 +1429,6 @@ namespace MBBSEmu.HostProcess.ExportedModules
             _logger.Info($"MODULE pointer ({Module.Memory.GetVariablePointer("MODULE") + (Module.StateCode * 2)}) set to {localModuleStructPointer}");
             _logger.Info($"Module Description set to {Module.ModuleDescription}");
 #endif
-
-            if (string.IsNullOrEmpty(Module.MenuOptionKey)) Module.MenuOptionKey = (Module.StateCode + 1).ToString();
         }
 
         /// <summary>

--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -376,6 +376,7 @@ namespace MBBSEmu.HostProcess.HostRoutines
             }
             else
             {
+                session.InputBuffer.SetLength(1);
                 session.CurrentModule = selectedMenuItem;
                 session.SessionState = EnumSessionState.EnteringModule;
                 session.SendToClient(new byte[] { 0x1B, 0x5B, 0x32, 0x4A });

--- a/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/MenuRoutines.cs
@@ -376,7 +376,6 @@ namespace MBBSEmu.HostProcess.HostRoutines
             }
             else
             {
-                session.InputBuffer.SetLength(1);
                 session.CurrentModule = selectedMenuItem;
                 session.SessionState = EnumSessionState.EnteringModule;
                 session.SendToClient(new byte[] { 0x1B, 0x5B, 0x32, 0x4A });

--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -235,16 +235,33 @@ namespace MBBSEmu
                 }
                 else if (_isModuleConfigFile)
                 {
+                    //Load Menu Option Keys
+                    var menuOptionKeyList = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789".ToCharArray().ToList();
+
                     //Load Config File
                     var moduleConfiguration = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory())
                         .AddJsonFile(_moduleConfigFileName, optional: false, reloadOnChange: true).Build();
 
                     foreach (var m in moduleConfiguration.GetSection("Modules").GetChildren())
                     {
-                        //Check for Non Character MenuOptionKey or duplicate MenuOptionKey
-                        if (!string.IsNullOrEmpty(m["MenuOptionKey"]) && (!char.IsLetter(m["MenuOptionKey"][0]) || _moduleConfigurations.Any(x => x.MenuOptionKey == m["MenuOptionKey"])))
+                        //Check for available MenuOptionKeys
+                        if (menuOptionKeyList.Count < 1)
                         {
-                            _logger.Error($"Invalid menu option key for {m["Identifier"]}, module not loaded");
+                            _logger.Error($"Maximum module limit reached -- {m["Identifier"]} not loaded");
+                            continue;
+                        }
+                        
+                        //Check for Non Character MenuOptionKey
+                        if (!string.IsNullOrEmpty(m["MenuOptionKey"]) && (!char.IsLetter(m["MenuOptionKey"][0])))
+                        {
+                            _logger.Error($"Invalid menu option key (NOT A-Z) for {m["Identifier"]}, module not loaded");
+                            continue;
+                        }
+
+                        //Check for duplicate MenuOptionKey
+                        if (!string.IsNullOrEmpty(m["MenuOptionKey"]) && _moduleConfigurations.Any(x => x.MenuOptionKey == m["MenuOptionKey"]))
+                        {
+                            _logger.Error($"Duplicate menu option key for {m["Identifier"]}, module not loaded");
                             continue;
                         }
 
@@ -253,6 +270,17 @@ namespace MBBSEmu
                         {
                             _logger.Error($"Module {m["Identifier"]} already loaded, duplicate instance not loaded");
                             continue;
+                        }
+
+                        //If MenuOptionKey, remove from allowable list
+                        if (!string.IsNullOrEmpty(m["MenuOptionKey"]))
+                            menuOptionKeyList.Remove(char.Parse(m["MenuOptionKey"]));
+                        
+                        //Check for missing MenuOptionKey, assign, remove from allowable list
+                        if (string.IsNullOrEmpty(m["MenuOptionKey"]))
+                        {
+                            m["MenuOptionKey"] = menuOptionKeyList[0].ToString();
+                            menuOptionKeyList.RemoveAt(0);
                         }
 
                         //Load Modules


### PR DESCRIPTION
*Set InputBuffer length to 1 before entering module
*Fixes extra characters from being sent to module (when menu items >9 or menuoption key that is 2 chars)
*Modules behave strangely when setting to 0