### PR TITLE
Zero pad integer values on printf with width specifiers

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/prf_Tests.cs
@@ -18,6 +18,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [InlineData("%u", "1", (ushort)1)]
         [InlineData("%u", "0", (ushort)0)]
         [InlineData("%u", "65535", (ushort)0xFFFF)]
+        [InlineData("ITEM%3.3d", "ITEM010", (ushort)10)]
         [InlineData("%s-%d", "TEST-1", "TEST", (ushort)1)]
         [InlineData("%s-%ld", "TEST-2147483647", "TEST", 2147483647)]
         [InlineData("%s-%ld-%d-%s", "TEST-2147483647-1-FOO", "TEST", 2147483647, (ushort)1, "FOO")]

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -391,6 +391,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
                         continue;
                     }
 
+                    var padCharacter = ' ';
+
                     switch ((char)stringToParse[i])
                     {
                         //Character
@@ -456,6 +458,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
                         case 'd':
                         case 'u':
                             {
+                                padCharacter = '0';
+
                                 long value;
                                 if (isVsPrintf)
                                 {
@@ -545,7 +549,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                             {
                                 //Pad at the end
                                 while (msFormattedValue.Length < stringWidth)
-                                    msFormattedValue.WriteByte((byte)' ');
+                                    msFormattedValue.WriteByte((byte)padCharacter);
                             }
                             else
                             {
@@ -553,7 +557,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                                 var valueCache = msFormattedValue.ToArray();
                                 msFormattedValue.SetLength(0);
                                 while (msFormattedValue.Length < stringWidth - valueCache.Length)
-                                    msFormattedValue.WriteByte((byte)' ');
+                                    msFormattedValue.WriteByte((byte)padCharacter);
 
                                 msFormattedValue.Write(valueCache);
                             }


### PR DESCRIPTION
Fixes 332

See page 196/199 in the Borland C++ manual