### PR TITLE
Use an interface to retrieve time

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
@@ -37,6 +37,7 @@ namespace MBBSEmu.Tests.ExportedModules
         protected const ushort STACK_SEGMENT = 0;
         protected const ushort CODE_SEGMENT = 1;
 
+        protected FakeClock fakeClock = new FakeClock();
         protected CpuCore mbbsEmuCpuCore;
         protected MemoryCore mbbsEmuMemoryCore;
         protected CpuRegisters mbbsEmuCpuRegisters;
@@ -53,7 +54,7 @@ namespace MBBSEmu.Tests.ExportedModules
             mbbsEmuMemoryCore = new MemoryCore();
             mbbsEmuCpuRegisters = new CpuRegisters();
             mbbsEmuCpuCore = new CpuCore();
-            mbbsModule = new MbbsModule(FileUtility.CreateForTest(), _serviceResolver.GetService<IClock>(), _serviceResolver.GetService<ILogger>(), null, modulePath, mbbsEmuMemoryCore);
+            mbbsModule = new MbbsModule(FileUtility.CreateForTest(), fakeClock, _serviceResolver.GetService<ILogger>(), null, modulePath, mbbsEmuMemoryCore);
 
             testSessions = new PointerDictionary<SessionBase>();
             testSessions.Allocate(new TestSession(null));

--- a/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
@@ -3,6 +3,7 @@ using MBBSEmu.CPU;
 using MBBSEmu.Database.Repositories.Account;
 using MBBSEmu.Database.Repositories.AccountKey;
 using MBBSEmu.Database.Session;
+using MBBSEmu.Date;
 using MBBSEmu.DependencyInjection;
 using MBBSEmu.Disassembler.Artifacts;
 using MBBSEmu.IO;
@@ -52,13 +53,14 @@ namespace MBBSEmu.Tests.ExportedModules
             mbbsEmuMemoryCore = new MemoryCore();
             mbbsEmuCpuRegisters = new CpuRegisters();
             mbbsEmuCpuCore = new CpuCore();
-            mbbsModule = new MbbsModule(FileUtility.CreateForTest(), _serviceResolver.GetService<ILogger>(), null, modulePath, mbbsEmuMemoryCore);
+            mbbsModule = new MbbsModule(FileUtility.CreateForTest(), _serviceResolver.GetService<IClock>(), _serviceResolver.GetService<ILogger>(), null, modulePath, mbbsEmuMemoryCore);
 
             testSessions = new PointerDictionary<SessionBase>();
             testSessions.Allocate(new TestSession(null));
             testSessions.Allocate(new TestSession(null));
 
             majorbbs = new HostProcess.ExportedModules.Majorbbs(
+                _serviceResolver.GetService<IClock>(),
                 _serviceResolver.GetService<ILogger>(),
                 _serviceResolver.GetService<AppSettings>(),
                 _serviceResolver.GetService<IFileUtility>(),
@@ -69,6 +71,7 @@ namespace MBBSEmu.Tests.ExportedModules
                 _serviceResolver.GetService<IAccountRepository>());
 
             galgsbl = new HostProcess.ExportedModules.Galgsbl(
+                _serviceResolver.GetService<IClock>(),
                 _serviceResolver.GetService<ILogger>(),
                 _serviceResolver.GetService<AppSettings>(),
                 _serviceResolver.GetService<IFileUtility>(),
@@ -112,6 +115,7 @@ namespace MBBSEmu.Tests.ExportedModules
 
             //Redeclare to re-allocate memory values that have been cleared
             majorbbs = new HostProcess.ExportedModules.Majorbbs(
+                _serviceResolver.GetService<IClock>(),
                 _serviceResolver.GetService<ILogger>(),
                 _serviceResolver.GetService<AppSettings>(),
                 _serviceResolver.GetService<IFileUtility>(),
@@ -122,6 +126,7 @@ namespace MBBSEmu.Tests.ExportedModules
                 _serviceResolver.GetService<IAccountRepository>());
 
             galgsbl = new HostProcess.ExportedModules.Galgsbl(
+                _serviceResolver.GetService<IClock>(),
                 _serviceResolver.GetService<ILogger>(),
                 _serviceResolver.GetService<AppSettings>(),
                 _serviceResolver.GetService<IFileUtility>(),

--- a/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
+++ b/MBBSEmu.Tests/ExportedModules/ExportedModuleTestBase.cs
@@ -37,7 +37,7 @@ namespace MBBSEmu.Tests.ExportedModules
         protected const ushort STACK_SEGMENT = 0;
         protected const ushort CODE_SEGMENT = 1;
 
-        protected FakeClock fakeClock = new FakeClock();
+        protected readonly FakeClock fakeClock = new FakeClock();
         protected CpuCore mbbsEmuCpuCore;
         protected MemoryCore mbbsEmuMemoryCore;
         protected CpuRegisters mbbsEmuCpuRegisters;
@@ -45,12 +45,14 @@ namespace MBBSEmu.Tests.ExportedModules
         protected HostProcess.ExportedModules.Majorbbs majorbbs;
         protected HostProcess.ExportedModules.Galgsbl galgsbl;
         protected PointerDictionary<SessionBase> testSessions;
-        protected ServiceResolver _serviceResolver = new ServiceResolver(SessionBuilder.ForTest($"MBBSDb_{RANDOM.Next()}"));
+        protected readonly ServiceResolver _serviceResolver;
 
         protected ExportedModuleTestBase() : this(Path.GetTempPath()) {}
 
         protected ExportedModuleTestBase(string modulePath)
         {
+            _serviceResolver = new ServiceResolver(fakeClock, SessionBuilder.ForTest($"MBBSDb_{RANDOM.Next()}"));
+
             mbbsEmuMemoryCore = new MemoryCore();
             mbbsEmuCpuRegisters = new CpuRegisters();
             mbbsEmuCpuCore = new CpuCore();

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/daytoday_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/daytoday_Tests.cs
@@ -9,19 +9,23 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
     {
         private const int DAYTODAY_ORDINAL = 155;
 
-        [Fact]
-        public void daytoday_Test()
+        [Theory]
+        [InlineData(1979, 4, 1, DayOfWeek.Sunday)]
+        [InlineData(1979, 4, 2, DayOfWeek.Monday)]
+        [InlineData(1979, 4, 3, DayOfWeek.Tuesday)]
+        [InlineData(1979, 4, 4, DayOfWeek.Wednesday)]
+        [InlineData(1979, 4, 5, DayOfWeek.Thursday)]
+        [InlineData(1979, 4, 6, DayOfWeek.Friday)]
+        [InlineData(1979, 4, 7, DayOfWeek.Saturday)]
+        [InlineData(1979, 4, 8, DayOfWeek.Sunday)]
+        public void daytoday_Test(int year, int month, int day, DayOfWeek expectedDayOfWeek)
         {
             //Reset State
             Reset();
 
-            fakeClock.Now = new DateTime(1979, 4, 1); // Sunday (0)
+            fakeClock.Now = new DateTime(year, month, day);
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, DAYTODAY_ORDINAL, new List<IntPtr16>());
-            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
-
-            fakeClock.Now = new DateTime(1979, 4, 2); // Monday (1)
-            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, DAYTODAY_ORDINAL, new List<IntPtr16>());
-            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+            Assert.Equal((int)expectedDayOfWeek, mbbsEmuCpuRegisters.AX);
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/daytoday_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/daytoday_Tests.cs
@@ -15,26 +15,13 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Reset State
             Reset();
 
+            fakeClock.Now = new DateTime(1979, 4, 1); // Sunday (0)
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, DAYTODAY_ORDINAL, new List<IntPtr16>());
+            Assert.Equal(0, mbbsEmuCpuRegisters.AX);
 
-            //Verify Results
-            ExecutePropertyTest(DAYTODAY_ORDINAL);
-
-            fakeClock.Now = new DateTime(1979, 3, 8);
-            //Expected Results based on the Day of the Week
-            var expectedResult = DateTime.Now.DayOfWeek switch
-            {
-                DayOfWeek.Sunday => 0,
-                DayOfWeek.Monday => 1,
-                DayOfWeek.Tuesday => 2,
-                DayOfWeek.Wednesday => 3,
-                DayOfWeek.Thursday => 4,
-                DayOfWeek.Friday => 5,
-                DayOfWeek.Saturday => 6,
-                _ => throw new ArgumentOutOfRangeException()
-            };
-
-            Assert.Equal(expectedResult, mbbsEmuCpuRegisters.AX);
+            fakeClock.Now = new DateTime(1979, 4, 2); // Monday (1)
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, DAYTODAY_ORDINAL, new List<IntPtr16>());
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/daytoday_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/daytoday_Tests.cs
@@ -20,6 +20,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Verify Results
             ExecutePropertyTest(DAYTODAY_ORDINAL);
 
+            fakeClock.Now = new DateTime(1979, 3, 8);
             //Expected Results based on the Day of the Week
             var expectedResult = DateTime.Now.DayOfWeek switch
             {

--- a/MBBSEmu/DOS/ExeRuntime.cs
+++ b/MBBSEmu/DOS/ExeRuntime.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.Disassembler;
 using MBBSEmu.Disassembler.Artifacts;
 using MBBSEmu.DOS.Interrupts;
@@ -34,14 +35,14 @@ namespace MBBSEmu.DOS
 
         private readonly List<string> _environmentVariables;
 
-        public ExeRuntime(MZFile file, List<string> environmentVariables, ILogger logger)
+        public ExeRuntime(MZFile file, List<string> environmentVariables, IClock clock, ILogger logger)
         {
             _logger = logger;
             File = file;
             Memory = new MemoryCore();
             Cpu = new CpuCore(_logger);
             Registers = new CpuRegisters();
-            Cpu.Reset(Memory, Registers, null, new List<IInterruptHandler> { new Int21h(Registers, Memory), new Int1Ah(Registers, Memory), new Int3Eh() });
+            Cpu.Reset(Memory, Registers, null, new List<IInterruptHandler> { new Int21h(Registers, Memory, clock), new Int1Ah(Registers, Memory, clock), new Int3Eh() });
             _environmentVariables = environmentVariables;
             PSP_SEGMENT = (ushort)(file.Segments.Count + 0x10);
 

--- a/MBBSEmu/DOS/Interrupts/Int1Ah.cs
+++ b/MBBSEmu/DOS/Interrupts/Int1Ah.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.Memory;
 using System;
 
@@ -11,13 +12,15 @@ namespace MBBSEmu.DOS.Interrupts
     {
         private CpuRegisters _registers { get; init; }
         private IMemoryCore _memory { get; init; }
+        private IClock _clock { get; init; }
 
         public byte Vector => 0x1A;
 
-        public Int1Ah(CpuRegisters registers, IMemoryCore memory)
+        public Int1Ah(CpuRegisters registers, IMemoryCore memory, IClock clock)
         {
             _registers = registers;
             _memory = memory;
+            _clock = clock;
         }
 
         public void Handle()
@@ -38,7 +41,7 @@ namespace MBBSEmu.DOS.Interrupts
                          */
 
                         var secondsSinceMidnight =
-                            (uint)((DateTime.Now - new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day)).TotalSeconds * 18.2);
+                            (uint)((_clock.Now - new DateTime(_clock.Now.Year, _clock.Now.Month, _clock.Now.Day)).TotalSeconds * 18.2);
 
                         _registers.AL = 0;
                         _registers.CX = (ushort) (secondsSinceMidnight & 0xFFFF);

--- a/MBBSEmu/DOS/Interrupts/Int21h.cs
+++ b/MBBSEmu/DOS/Interrupts/Int21h.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.Extensions;
 using MBBSEmu.Memory;
 using System;
@@ -16,6 +17,7 @@ namespace MBBSEmu.DOS.Interrupts
     {
         private CpuRegisters _registers { get; init; }
         private IMemoryCore _memory { get; init; }
+        private IClock _clock { get; init; }
 
         /// <summary>
         ///     INT 21h defined Disk Transfer Area
@@ -28,10 +30,11 @@ namespace MBBSEmu.DOS.Interrupts
 
         private readonly Dictionary<byte, IntPtr16> _interruptVectors;
 
-        public Int21h(CpuRegisters registers, IMemoryCore memory)
+        public Int21h(CpuRegisters registers, IMemoryCore memory, IClock clock)
         {
             _registers = registers;
             _memory = memory;
+            _clock = clock;
             _interruptVectors = new Dictionary<byte, IntPtr16>();
         }
 
@@ -73,10 +76,10 @@ namespace MBBSEmu.DOS.Interrupts
                         //DOS - GET CURRENT DATE
                         //Return: DL = day, DH = month, CX = year
                         //AL = day of the week(0 = Sunday, 1 = Monday, etc.)
-                        _registers.DL = (byte)DateTime.Now.Day;
-                        _registers.DH = (byte)DateTime.Now.Month;
-                        _registers.CX = (ushort)DateTime.Now.Year;
-                        _registers.AL = (byte)DateTime.Now.DayOfWeek;
+                        _registers.DL = (byte)_clock.Now.Day;
+                        _registers.DH = (byte)_clock.Now.Month;
+                        _registers.CX = (ushort)_clock.Now.Year;
+                        _registers.AL = (byte)_clock.Now.DayOfWeek;
                         return;
                     }
                 case 0x2F:
@@ -88,7 +91,7 @@ namespace MBBSEmu.DOS.Interrupts
                             Returns:	ES:BX = Segment.offset of current DTA
                          */
                         DiskTransferArea = _memory.GetOrAllocateVariablePointer("Int21h-DTA", 0xFF);
-                        
+
                         _registers.ES = DiskTransferArea.Segment;
                         _registers.BX = DiskTransferArea.Offset;
                         return;
@@ -171,7 +174,7 @@ namespace MBBSEmu.DOS.Interrupts
                     {
                         /*
                             INT 21 - AH = 44H DOS Get Device Information
-                            
+
                             Sub-Function Definition is in AL
                          */
                         switch (_registers.AL)
@@ -260,7 +263,7 @@ namespace MBBSEmu.DOS.Interrupts
                         /*
                             INT 21 - AH = 62h DOS 3.x - GET PSP ADDRESS
                             Return: BX = segment address of PSP
-                            
+
                             This is only set when an EXE is running, thus should only be called from
                             an EXE.
                          */

--- a/MBBSEmu/Date/FakeClock.cs
+++ b/MBBSEmu/Date/FakeClock.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace MBBSEmu.Date
+{
+  /// <summary>
+  ///   Fake clock implementation which supports changing Now.
+  /// </summary>
+  public class FakeClock : IClock
+  {
+    private DateTime _now = DateTime.Now;
+
+    public DateTime Now
+    {
+      get => _now;
+      set => _now = value;
+    }
+  }
+}

--- a/MBBSEmu/Date/FakeClock.cs
+++ b/MBBSEmu/Date/FakeClock.cs
@@ -7,12 +7,11 @@ namespace MBBSEmu.Date
   /// </summary>
   public class FakeClock : IClock
   {
-    private DateTime _now = DateTime.Now;
+    public DateTime Now { get; set; }
 
-    public DateTime Now
+    public FakeClock()
     {
-      get => _now;
-      set => _now = value;
+      Now = DateTime.Now;
     }
   }
 }

--- a/MBBSEmu/Date/IClock.cs
+++ b/MBBSEmu/Date/IClock.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MBBSEmu.Date
+{
+  /// <summary>
+  ///   An interface to return the current date/time.
+  /// </summary>
+  public interface IClock
+  {
+    DateTime Now { get; }
+  }
+}

--- a/MBBSEmu/Date/SystemClock.cs
+++ b/MBBSEmu/Date/SystemClock.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace MBBSEmu.Date
+{
+  /// <summary>
+  ///   Clock implementation using the local system clock.
+  /// </summary>
+  public class SystemClock : IClock
+  {
+    public DateTime Now { get => DateTime.Now; }
+  }
+}

--- a/MBBSEmu/DependencyInjection/ServiceResolver.cs
+++ b/MBBSEmu/DependencyInjection/ServiceResolver.cs
@@ -1,6 +1,7 @@
 using MBBSEmu.Database.Repositories.Account;
 using MBBSEmu.Database.Repositories.AccountKey;
 using MBBSEmu.Database.Session;
+using MBBSEmu.Date;
 using MBBSEmu.HostProcess;
 using MBBSEmu.HostProcess.Fsd;
 using MBBSEmu.HostProcess.GlobalRoutines;
@@ -64,6 +65,9 @@ namespace MBBSEmu.DependencyInjection
             AddSingleton<IGlobalRoutine, SysopGlobal>(overrides);
             AddSingleton<IMbbsHost, MbbsHost>(overrides);
             _serviceCollection.AddTransient<ISocketServer, SocketServer>();
+
+            //System clock
+            AddSingleton<IClock, SystemClock>(overrides);
 
             _provider = _serviceCollection.BuildServiceProvider();
         }

--- a/MBBSEmu/HostProcess/ExecutionUnits/ExecutionUnit.cs
+++ b/MBBSEmu/HostProcess/ExecutionUnits/ExecutionUnit.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.DOS.Interrupts;
 using MBBSEmu.HostProcess.ExportedModules;
 using MBBSEmu.Memory;
@@ -34,14 +35,14 @@ namespace MBBSEmu.HostProcess.ExecutionUnits
         /// </summary>
         public readonly Dictionary<ushort, IExportedModule> ExportedModuleDictionary;
 
-        public ExecutionUnit(IMemoryCore moduleMemory, Dictionary<ushort, IExportedModule> exportedModuleDictionary, ILogger logger)
+        public ExecutionUnit(IMemoryCore moduleMemory, IClock clock, Dictionary<ushort, IExportedModule> exportedModuleDictionary, ILogger logger)
         {
             ModuleCpu = new CpuCore(logger);
             ModuleCpuRegisters = new CpuRegisters();
             ModuleMemory = moduleMemory;
             ExportedModuleDictionary = exportedModuleDictionary;
 
-            ModuleCpu.Reset(ModuleMemory, ModuleCpuRegisters, ExternalFunctionDelegate, new List<IInterruptHandler> { new Int21h(ModuleCpuRegisters, ModuleMemory), new Int3Eh(), new Int1Ah(ModuleCpuRegisters, ModuleMemory) });
+            ModuleCpu.Reset(ModuleMemory, ModuleCpuRegisters, ExternalFunctionDelegate, new List<IInterruptHandler> { new Int21h(ModuleCpuRegisters, ModuleMemory, clock), new Int3Eh(), new Int1Ah(ModuleCpuRegisters, ModuleMemory, clock) });
         }
 
         private ReadOnlySpan<byte> ExternalFunctionDelegate(ushort ordinal, ushort functionOrdinal)

--- a/MBBSEmu/HostProcess/ExportedModules/Doscalls.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Doscalls.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
 using MBBSEmu.Module;
@@ -20,8 +21,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         public const ushort DosSegmentBase = 0x200;
         public ushort DosSegmentOffset = 0;
 
-        internal Doscalls(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
-            logger, configuration, fileUtility, globalCache, module, channelDictionary)
+        internal Doscalls(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
+            clock, logger, configuration, fileUtility, globalCache, module, channelDictionary)
         {
         }
 

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -1,5 +1,6 @@
 using MBBSEmu.Btrieve;
 using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.Extensions;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
@@ -63,6 +64,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         public readonly PointerDictionary<McvFile> McvPointerDictionary;
 
         private protected readonly ILogger _logger;
+        private protected readonly IClock _clock;
         private protected readonly AppSettings _configuration;
         private protected readonly IFileUtility _fileFinder;
         private protected readonly IGlobalCache _globalCache;
@@ -88,8 +90,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private protected const ushort ACCBB_BASE_SEGMENT = 0x3001;
 
 
-        private protected ExportedModuleBase(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary)
+        private protected ExportedModuleBase(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary)
         {
+            _clock = clock;
             _logger = logger;
             _configuration = configuration;
             _fileFinder = fileUtility;
@@ -641,7 +644,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                         break;
 
                     case "DATE":
-                        newOutputBuffer.Write(Encoding.ASCII.GetBytes(DateTime.Now.ToString("MM/dd/yyyy")));
+                        newOutputBuffer.Write(Encoding.ASCII.GetBytes(_clock.Now.ToString("MM/dd/yyyy")));
                         break;
 
                     //Registered Variables

--- a/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
@@ -1,4 +1,5 @@
 using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
 using MBBSEmu.Module;
@@ -6,7 +7,6 @@ using MBBSEmu.Server;
 using MBBSEmu.Session;
 using NLog;
 using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 
@@ -34,10 +34,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private const ushort ERROR_CHANNEL_NOT_DEFINED = 0xFFF6;
         private const ushort ERROR_CHANNEL_OUT_OF_RANGE = 0xFFF5;
 
-        public Galgsbl(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
-            logger, configuration, fileUtility, globalCache, module, channelDictionary)
+        public Galgsbl(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
+            clock, logger, configuration, fileUtility, globalCache, module, channelDictionary)
         {
-            _startDate = DateTime.Now;
+            _startDate = clock.Now;
             Module.Memory.AllocateVariable("BTURNO", 9);
 
             //Check for Module Specific BTURNO #
@@ -87,7 +87,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             // completed. This crashes the test.
             if (Module.Memory.TryGetVariablePointer("TICKER", out var tickerPointer))
             {
-                var seconds = (ushort)((DateTime.Now - _startDate).TotalSeconds % 0xFFFF);
+                var seconds = (ushort)((_clock.Now - _startDate).TotalSeconds % 0xFFFF);
                 Module.Memory.SetWord(tickerPointer, seconds);
             }
         }
@@ -1002,7 +1002,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
         /// <summary>
         ///     Takes the specified character and adds it directly to the channel input buffer
-        /// 
+        ///
         ///     Signature: void chiinp(int chan,char c);
         /// </summary>
         private void chiinp()

--- a/MBBSEmu/HostProcess/ExportedModules/Galme.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galme.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
 using MBBSEmu.Module;
@@ -16,8 +17,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         public const ushort Segment = 0xFFFC;
 
-        internal Galme(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
-            logger, configuration, fileUtility, globalCache, module, channelDictionary)
+        internal Galme(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
+            clock, logger, configuration, fileUtility, globalCache, module, channelDictionary)
         {
             var txtlenPointer = Module.Memory.AllocateVariable("TXTLEN", 0x2);
             Module.Memory.SetWord(txtlenPointer, 0x400);

--- a/MBBSEmu/HostProcess/ExportedModules/Galmsg.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galmsg.cs
@@ -1,4 +1,5 @@
 ﻿using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
 using MBBSEmu.Module;
@@ -10,8 +11,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
 {
     public class Galmsg : ExportedModuleBase, IExportedModule
     {
-        internal Galmsg(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
-            logger, configuration, fileUtility, globalCache, module, channelDictionary)
+        internal Galmsg(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
+            clock, logger, configuration, fileUtility, globalCache, module, channelDictionary)
         {
         }
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3,6 +3,7 @@ using MBBSEmu.Btrieve.Enums;
 using MBBSEmu.CPU;
 using MBBSEmu.Database.Repositories.Account;
 using MBBSEmu.Database.Repositories.AccountKey;
+using MBBSEmu.Date;
 using MBBSEmu.Extensions;
 using MBBSEmu.HostProcess.Fsd;
 using MBBSEmu.HostProcess.Structs;
@@ -89,8 +90,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
             FilePointerDictionary.Clear();
         }
 
-        public Majorbbs(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary, IAccountKeyRepository accountKeyRepository, IAccountRepository accountRepository) : base(
-            logger, configuration, fileUtility, globalCache, module, channelDictionary)
+        public Majorbbs(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary, IAccountKeyRepository accountKeyRepository, IAccountRepository accountRepository) : base(
+            clock, logger, configuration, fileUtility, globalCache, module, channelDictionary)
         {
             _accountKeyRepository = accountKeyRepository;
             _accountRepository = accountRepository;
@@ -1309,7 +1310,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private void time()
         {
             //For now, ignore the input pointer for time_t
-            var passedSeconds = (int)(DateTime.Now - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+            var passedSeconds = (int)(_clock.Now - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
 
             Registers.DX = (ushort)(passedSeconds >> 16);
             Registers.AX = (ushort)(passedSeconds & 0xFFFF);
@@ -1728,7 +1729,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             //From DOSFACE.H:
             //#define dddate(mon,day,year) (((mon)<<5)+(day)+(((year)-1980)<<9))
-            var packedDate = (DateTime.Now.Month << 5) + DateTime.Now.Day + ((DateTime.Now.Year - 1980) << 9);
+            var packedDate = (_clock.Now.Month << 5) + _clock.Now.Day + ((_clock.Now.Year - 1980) << 9);
 
 #if DEBUG
             _logger.Info($"Returned packed date: {packedDate}");
@@ -2720,7 +2721,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             //From DOSFACE.H:
             //#define dttime(hour,min,sec) (((hour)<<11)+((min)<<5)+((sec)>>1))
-            var packedTime = (DateTime.Now.Hour << 11) + (DateTime.Now.Minute << 5) + (DateTime.Now.Second >> 1);
+            var packedTime = (_clock.Now.Hour << 11) + (_clock.Now.Minute << 5) + (_clock.Now.Second >> 1);
 
 #if DEBUG
             _logger.Info($"Returned packed time: {packedTime}");
@@ -3763,10 +3764,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
                     {
                         var returnValue = new CpuRegisters
                         {
-                            CH = (byte)DateTime.Now.Hour,
-                            CL = (byte)DateTime.Now.Minute,
-                            DH = (byte)DateTime.Now.Second,
-                            DL = (byte)(DateTime.Now.Millisecond / 100)
+                            CH = (byte)_clock.Now.Hour,
+                            CL = (byte)_clock.Now.Minute,
+                            DH = (byte)_clock.Now.Second,
+                            DL = (byte)(_clock.Now.Millisecond / 100)
                         };
                         Module.Memory.SetArray(parameterOffset2, returnValue.ToRegs());
                         return;
@@ -4003,7 +4004,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             //From DOSFACE.H:
             //#define dttime(hour,min,sec) (((hour)<<11)+((min)<<5)+((sec)>>1))
-            //var packedTime = (DateTime.Now.Hour << 11) + (DateTime.Now.Minute << 5) + (DateTime.Now.Second >> 1);
+            //var packedTime = (_clock.Now.Hour << 11) + (_clock.Now.Minute << 5) + (_clock.Now.Second >> 1);
 
             var packedTime = GetParameter(0);
 
@@ -4011,7 +4012,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var unpackedMinutes = (packedTime >> 5 & 0x1F);
             var unpackedSeconds = packedTime & 0xF;
 
-            var unpackedTime = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, unpackedHour,
+            var unpackedTime = new DateTime(_clock.Now.Year, _clock.Now.Month, _clock.Now.Day, unpackedHour,
                 unpackedMinutes, unpackedSeconds);
 
             var timeString = unpackedTime.ToString("HH:mm:ss");
@@ -5933,7 +5934,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             var datePointer = GetParameterPointer(0);
 
-            var dateStruct = new DateStruct(DateTime.Now);
+            var dateStruct = new DateStruct(_clock.Now);
 
             Module.Memory.SetArray(datePointer, dateStruct.Data);
         }
@@ -6437,7 +6438,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var packedTime = (ushort)((info.CreationTime.Hour << 11) + (info.CreationTime.Minute << 5) + (info.CreationTime.Second >> 1));
             var packedTimeData = BitConverter.GetBytes(packedTime);
 
-            var packedDate = (ushort)(((DateTime.Now.Year - 1980) << 9) + (DateTime.Now.Month << 5) + DateTime.Now.Day);
+            var packedDate = (ushort)(((_clock.Now.Year - 1980) << 9) + (_clock.Now.Month << 5) + _clock.Now.Day);
             var packedDateData = BitConverter.GetBytes(packedDate);
 
             var ftimeStruct = new byte[4];
@@ -7385,7 +7386,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// </summary>
         public void daytoday()
         {
-            Registers.AX = (ushort)DateTime.Now.DayOfWeek;
+            Registers.AX = (ushort)_clock.Now.DayOfWeek;
         }
 
         /// <summary>

--- a/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
@@ -1,6 +1,7 @@
 using MBBSEmu.Btrieve;
 using MBBSEmu.Btrieve.Enums;
 using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.HostProcess.Structs;
 using MBBSEmu.IO;
 using MBBSEmu.Memory;
@@ -21,8 +22,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         public const ushort Segment = 0xFFFD;
 
-        internal Phapi(ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
-            logger, configuration, fileUtility, globalCache, module, channelDictionary)
+        internal Phapi(IClock clock, ILogger logger, AppSettings configuration, IFileUtility fileUtility, IGlobalCache globalCache, MbbsModule module, PointerDictionary<SessionBase> channelDictionary) : base(
+            clock, logger, configuration, fileUtility, globalCache, module, channelDictionary)
         {
         }
 

--- a/MBBSEmu/HostProcess/IMbbsHost.cs
+++ b/MBBSEmu/HostProcess/IMbbsHost.cs
@@ -1,8 +1,8 @@
+using MBBSEmu.Date;
 using MBBSEmu.Module;
 using MBBSEmu.Server;
 using MBBSEmu.Session;
 using NLog;
-using System;
 using System.Collections.Generic;
 using System.Threading;
 
@@ -64,6 +64,8 @@ namespace MBBSEmu.HostProcess
         /// </summary>
         public void GenerateAPIReport();
 
-        public ILogger Logger { get; set; }
+        public ILogger Logger { get; init; }
+
+        public IClock Clock { get; init; }
     }
 }

--- a/MBBSEmu/Module/MBBSModule.cs
+++ b/MBBSEmu/Module/MBBSModule.cs
@@ -1,4 +1,5 @@
 using MBBSEmu.CPU;
+using MBBSEmu.Date;
 using MBBSEmu.Disassembler;
 using MBBSEmu.HostProcess.ExecutionUnits;
 using MBBSEmu.HostProcess.ExportedModules;
@@ -26,6 +27,7 @@ namespace MBBSEmu.Module
     public class MbbsModule
     {
         private protected readonly ILogger _logger;
+        private protected readonly IClock _clock;
         private protected readonly IFileUtility _fileUtility;
 
         /// <summary>
@@ -44,7 +46,7 @@ namespace MBBSEmu.Module
         ///     Directory Path of Module
         /// </summary>
         public readonly string ModulePath;
-        
+
         /// <summary>
         ///     Menu Option Key of Module
         /// </summary>
@@ -138,9 +140,10 @@ namespace MBBSEmu.Module
         /// <param name="moduleIdentifier">Will be null in a test</param>
         /// <param name="path"></param>
         /// <param name="memoryCore"></param>
-        public MbbsModule(IFileUtility fileUtility, ILogger logger, string moduleIdentifier, string path = "", MemoryCore memoryCore = null)
+        public MbbsModule(IFileUtility fileUtility, IClock clock, ILogger logger, string moduleIdentifier, string path = "", MemoryCore memoryCore = null)
         {
             _fileUtility = fileUtility;
+            _clock = clock;
             _logger = logger;
             ModuleIdentifier = moduleIdentifier;
 
@@ -251,7 +254,7 @@ namespace MBBSEmu.Module
             if (!ExecutionUnits.TryDequeue(out var executionUnit))
             {
                 _logger.Warn($"{ModuleIdentifier} exhausted execution Units, creating additional");
-                executionUnit = new ExecutionUnit(Memory, ExportedModuleDictionary, _logger);
+                executionUnit = new ExecutionUnit(Memory, _clock, ExportedModuleDictionary, _logger);
             }
 
             var resultRegisters = executionUnit.Execute(entryPoint, channelNumber, simulateCallFar, bypassSetState, initialStackValues, initialStackPointer);

--- a/MBBSEmu/Program.cs
+++ b/MBBSEmu/Program.cs
@@ -1,6 +1,7 @@
 using MBBSEmu.Btrieve;
 using MBBSEmu.Database.Repositories.Account;
 using MBBSEmu.Database.Repositories.AccountKey;
+using MBBSEmu.Date;
 using MBBSEmu.DependencyInjection;
 using MBBSEmu.HostProcess;
 using MBBSEmu.HostProcess.Structs;
@@ -216,7 +217,7 @@ namespace MBBSEmu
                 if (!string.IsNullOrEmpty(_exeFile))
                 {
                     var mzFile = new MZFile(_exeFile);
-                    var exe = new ExeRuntime(mzFile, null, _logger);
+                    var exe = new ExeRuntime(mzFile, null, _serviceResolver.GetService<IClock>(), _logger);
                     exe.Load();
                     exe.Run();
                     return;


### PR DESCRIPTION
Useful to ensuring stable tests that rely on time. 
Could also be used for faking a time in mbbsemu, say for example using the same day when emulating.