### PR TITLE
Add tests for nctime(), now(), and time() --  ordinal update

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
@@ -10,15 +10,15 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int NCTIME_ORDINAL = 430;
 
         [Theory]
-        [InlineData(12, 4, 1, "12:04:01", true)]
+        [InlineData(12, 4, 10, "12:04:10", true)]
         [InlineData(3, 9, 2, "03:09:02", false)]
-        [InlineData(4, 11, 3, "04:11:03", true)]
+        [InlineData(4, 11, 16, "04:11:16", true)]
         [InlineData(7, 5, 4, "07:05:04", false)]
-        [InlineData(10, 1, 5, "10:01:05", true)]
-        [InlineData(14, 3, 7, "14:03:07", false)]
+        [InlineData(10, 1, 28, "10:01:28", true)]
+        [InlineData(14, 3, 36, "14:03:36", false)]
         [InlineData(18, 12, 8, "18:12:08", true)]
-        [InlineData(23, 1, 1, "23:01:01", false)]
-        [InlineData(23, 59, 59, "23:59:59", true)]
+        [InlineData(23, 1, 44, "23:01:44", false)]
+        [InlineData(23, 59, 58, "23:59:58", true)]
         public void nctime_Test(int hour, int minutes, int seconds, string expectedTime, bool allocateNCTIME)
         {
             //Reset State

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
@@ -11,11 +11,11 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         [Theory]
         [InlineData(12, 4, 10, "12:04:10", true)]
         [InlineData(3, 9, 2, "03:09:02", false)]
-        [InlineData(4, 11, 16, "04:11:16", true)]
-        [InlineData(7, 5, 4, "07:05:04", false)]
+        [InlineData(4, 11, 15, "04:11:14", true)]
+        [InlineData(7, 5, 3, "07:05:02", false)]
         [InlineData(10, 1, 28, "10:01:28", true)]
         [InlineData(14, 3, 36, "14:03:36", false)]
-        [InlineData(18, 12, 8, "18:12:08", true)]
+        [InlineData(18, 12, 7, "18:12:06", true)]
         [InlineData(23, 1, 44, "23:01:44", false)]
         [InlineData(23, 59, 58, "23:59:58", true)]
         public void nctime_Test(int hour, int minutes, int seconds, string expectedTime, bool allocateNCTIME)
@@ -23,7 +23,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Reset State
             Reset();
 
-            //Set Argument Values to be Passed In
+            //Set Argument Values to be Passed In -- Odd seconds are rounded down to next even number
             var packedTime = hour << 11 | minutes << 5 | seconds >> 1;
 
             if (allocateNCTIME)

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
@@ -35,7 +34,6 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Verify Results
             Assert.Equal(expectedTime, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("NCTIME", true)));
-
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/nctime_Tests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class nctime_Tests : ExportedModuleTestBase
+    {
+        private const int NCTIME_ORDINAL = 430;
+
+        [Theory]
+        [InlineData(12, 4, 1, "12:04:01", true)]
+        [InlineData(3, 9, 2, "03:09:02", false)]
+        [InlineData(4, 11, 3, "04:11:03", true)]
+        [InlineData(7, 5, 4, "07:05:04", false)]
+        [InlineData(10, 1, 5, "10:01:05", true)]
+        [InlineData(14, 3, 7, "14:03:07", false)]
+        [InlineData(18, 12, 8, "18:12:08", true)]
+        [InlineData(23, 1, 1, "23:01:01", false)]
+        [InlineData(23, 59, 59, "23:59:59", true)]
+        public void nctime_Test(int hour, int minutes, int seconds, string expectedTime, bool allocateNCTIME)
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            var packedTime = hour << 11 | minutes << 5 | seconds >> 1;
+
+            if (allocateNCTIME)
+                mbbsEmuMemoryCore.AllocateVariable("NCTIME", sizeof(int));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, NCTIME_ORDINAL, new List<ushort> { (ushort) packedTime });
+
+            //Verify Results
+            Assert.Equal(expectedTime, Encoding.ASCII.GetString(mbbsEmuMemoryCore.GetString("NCTIME", true)));
+
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/now_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/now_Tests.cs
@@ -9,21 +9,21 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const int NOW_ORDINAL = 435;
 
         [Theory]
-        [InlineData(12, 4, 10)]
-        [InlineData(3, 9, 2)]
-        [InlineData(4, 11, 16)]
-        [InlineData(7, 5, 4)]
-        [InlineData(10, 1, 28)]
-        [InlineData(14, 3, 36)]
-        [InlineData(18, 12, 8)]
-        [InlineData(23, 1, 44)]
-        [InlineData(23, 59, 58)]
-        public void now_Test(int hour, int minutes, int seconds)
+        [InlineData(12, 4, 10, 10)]
+        [InlineData(3, 9, 2, 2)]
+        [InlineData(4, 11, 15, 14)]
+        [InlineData(7, 5, 4, 4)]
+        [InlineData(10, 1, 28, 28)]
+        [InlineData(14, 3, 35, 34)]
+        [InlineData(18, 12, 8, 8)]
+        [InlineData(23, 1, 43, 42)]
+        [InlineData(23, 59, 58, 58)]
+        public void now_Test(int hour, int minutes, int seconds, int expectedSeconds)
         {
             //Reset State
             Reset();
 
-            //Set Argument Values to be Passed In
+            //Set Argument Values to be Passed In -- Odd seconds are rounded down to nearest even
             fakeClock.Now = new DateTime(2000, 1, 1, hour, minutes, seconds);
 
             //Execute Test
@@ -32,7 +32,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             //Verify Results
             Assert.Equal(hour, (mbbsEmuCpuRegisters.AX >> 11) & 0x1F);
             Assert.Equal(minutes, (mbbsEmuCpuRegisters.AX >> 5) & 0x3F);
-            Assert.Equal(seconds, (mbbsEmuCpuRegisters.AX << 1) & 0x3E);
+            Assert.Equal(expectedSeconds, (mbbsEmuCpuRegisters.AX << 1) & 0x3E);
         }
     }
 }

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/now_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/now_Tests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class now_Tests : ExportedModuleTestBase
+    {
+        private const int NOW_ORDINAL = 435;
+
+        [Theory]
+        [InlineData(12, 4, 10)]
+        [InlineData(3, 9, 2)]
+        [InlineData(4, 11, 16)]
+        [InlineData(7, 5, 4)]
+        [InlineData(10, 1, 28)]
+        [InlineData(14, 3, 36)]
+        [InlineData(18, 12, 8)]
+        [InlineData(23, 1, 44)]
+        [InlineData(23, 59, 58)]
+        public void now_Test(int hour, int minutes, int seconds)
+        {
+            //Reset State
+            Reset();
+
+            //Set Argument Values to be Passed In
+            fakeClock.Now = new DateTime(2000, 1, 1, hour, minutes, seconds);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, NOW_ORDINAL, new List<ushort>());
+
+            //Verify Results
+            Assert.Equal(hour, (mbbsEmuCpuRegisters.AX >> 11) & 0x1F);
+            Assert.Equal(minutes, (mbbsEmuCpuRegisters.AX >> 5) & 0x3F);
+            Assert.Equal(seconds, (mbbsEmuCpuRegisters.AX << 1) & 0x3E);
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/time_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/time_Tests.cs
@@ -1,0 +1,36 @@
+﻿using MBBSEmu.Memory;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace MBBSEmu.Tests.ExportedModules.Majorbbs
+{
+    public class time_Tests : ExportedModuleTestBase
+    {
+        private const int TIME_ORDINAL = 599;
+
+        [Theory]
+        [InlineData(1, 1, 2000, 23, 0, 1, 946767601)]
+        [InlineData(2, 2, 2010, 1, 30, 30, 1265074230)]
+        [InlineData(3, 3, 2020, 8, 45, 15, 1583225115)]
+        [InlineData(4, 22, 2035, 11, 0, 59, 2060852459)]
+        [InlineData(12, 31, 1980, 20, 59, 1, 347144341)]
+        [InlineData(1, 18, 2038, 2, 14, 7, 2147393647)]
+        [InlineData(1, 1, 1970, 0, 0, 0, 0)]
+        public void time_Test(int month, int day, int year, int hour, int minute, int second, int expectedUnixDate)
+        {
+            //Reset State
+            Reset();
+            
+            //Set Argument Values to be Passed In
+            fakeClock.Now = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, TIME_ORDINAL, new List<ushort> ());
+
+            //Verify Results
+            Assert.Equal(expectedUnixDate >> 16, mbbsEmuCpuRegisters.DX);
+            Assert.Equal(expectedUnixDate & 0xFFFF, mbbsEmuCpuRegisters.AX);
+        }
+    }
+}

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/time_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/time_Tests.cs
@@ -1,5 +1,4 @@
-﻿using MBBSEmu.Memory;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -29,8 +28,7 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, TIME_ORDINAL, new List<ushort> ());
 
             //Verify Results
-            Assert.Equal(expectedUnixDate >> 16, mbbsEmuCpuRegisters.DX);
-            Assert.Equal(expectedUnixDate & 0xFFFF, mbbsEmuCpuRegisters.AX);
+            Assert.Equal(expectedUnixDate, mbbsEmuCpuRegisters.GetLong());
         }
     }
 }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -4005,11 +4005,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 unpackedMinutes, unpackedSeconds);
 
             var timeString = unpackedTime.ToString("HH:mm:ss");
-
-            if (!Module.Memory.TryGetVariablePointer("NCTIME", out var variablePointer))
-            {
-                variablePointer = Module.Memory.AllocateVariable("NCTIME", (ushort)timeString.Length);
-            }
+            var variablePointer = Module.Memory.GetOrAllocateVariablePointer("NCTIME", (ushort) timeString.Length);
 
             Module.Memory.SetArray(variablePointer.Segment, variablePointer.Offset,
                 Encoding.Default.GetBytes(timeString));

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -3998,8 +3998,8 @@ namespace MBBSEmu.HostProcess.ExportedModules
             var packedTime = GetParameter(0);
 
             var unpackedHour = (packedTime >> 11) & 0x1F;
-            var unpackedMinutes = (packedTime >> 5 & 0x1F);
-            var unpackedSeconds = packedTime & 0xF;
+            var unpackedMinutes = (packedTime >> 5) & 0x3F;
+            var unpackedSeconds = (packedTime << 1) & 0x3E;
 
             var unpackedTime = new DateTime(_clock.Now.Year, _clock.Now.Month, _clock.Now.Day, unpackedHour,
                 unpackedMinutes, unpackedSeconds);


### PR DESCRIPTION
-1 second off if odd second

```c#
//From DOSFACE.H:
#define dttime(hour,min,sec) (((hour)<<11)+((min)<<5)+((sec)>>1))
var packedTime = (_clock.Now.Hour << 11) + (_clock.Now.Minute << 5) + (_clock.Now.Second >> 1);
```

PHP program I found
```php
/** Converts DOS time to Unix time */
function dosToUnixTime($dosTime) {
  $date = mktime(
    (($dosTime >> 11) & 0x1f), // hours
    (($dosTime >> 5) & 0x3f),  // minutes
    (($dosTime << 1) & 0x3e),  // seconds
    ((($dosTime >> 21) & 0x0f) - 1),   // month
    (($dosTime >> 16) & 0x1f),         // day
    ((($dosTime >> 25) & 0x7f) + 1980) // year
```

Reference from MSDN:
![image](https://user-images.githubusercontent.com/27604078/103172438-0c23ff00-4819-11eb-9116-a2161bd1e75b.png)
