### PR TITLE
Limit primary processing core to only run at set intervals = CPU REDUCTION

### DIFF
--- a/MBBSEmu.Tests/appsettings.json
+++ b/MBBSEmu.Tests/appsettings.json
@@ -12,6 +12,7 @@
   "Rlogin.PortPerModule": "True",
   "Database.File": "mbbsemu.db",
   "ANSI.Login": "test.ans",
+  "Timer.Hertz": "0",
   "Account.DefaultKeys": [
     "DEMO",
     "NORMAL",

--- a/MBBSEmu/Configuration.cs
+++ b/MBBSEmu/Configuration.cs
@@ -45,6 +45,7 @@ namespace MBBSEmu
         public bool RloginPortPerModule => GetAppSettingsFromConfiguration<bool>("Rlogin.PortPerModule");
         public string DatabaseFile => GetStringAppSettings("Database.File");
         public int BtrieveCacheSize => GetAppSettingsFromConfiguration<int>("Btrieve.CacheSize");
+        public int TimerHertz => GetAppSettingsFromConfiguration<int>("Timer.Hertz");
 
         //Optional Keys
         public string GetBTURNO(string moduleId) => ConfigurationRoot[$"GSBL.BTURNO.{moduleId}"];
@@ -125,6 +126,10 @@ namespace MBBSEmu
                         return (T)value;
                     case "Btrieve.CacheSize":
                         value = 4;
+                        Console.WriteLine($"{valueName} not specified in {Program._settingsFileName ?? Program.DefaultEmuSettingsFilename} -- setting default value: {value}");
+                        return (T)value;
+                    case "Timer.Hertz":
+                        value = 0;
                         Console.WriteLine($"{valueName} not specified in {Program._settingsFileName ?? Program.DefaultEmuSettingsFilename} -- setting default value: {value}");
                         return (T)value;
                     default:

--- a/MBBSEmu/HostProcess/IMbbsHost.cs
+++ b/MBBSEmu/HostProcess/IMbbsHost.cs
@@ -60,7 +60,7 @@ namespace MBBSEmu.HostProcess
         public void WaitForShutdown();
 
         /// <summary>
-        ///     TODO
+        ///    Causes the main worker thread to execute
         /// </summary>
         public void TriggerProcessing();
 

--- a/MBBSEmu/HostProcess/IMbbsHost.cs
+++ b/MBBSEmu/HostProcess/IMbbsHost.cs
@@ -60,6 +60,11 @@ namespace MBBSEmu.HostProcess
         public void WaitForShutdown();
 
         /// <summary>
+        ///     TODO
+        /// </summary>
+        public void TriggerProcessing();
+
+        /// <summary>
         ///     Generates API Report
         /// </summary>
         public void GenerateAPIReport();

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -92,7 +92,12 @@ namespace MBBSEmu.HostProcess
         ///     Timer that triggers when nightly cleanup should occur
         /// </summary>
         private readonly Timer _timer;
+        /// <summary>
+        ///     Timer that sets _timerEvent on a set interval, controlled by Timer.Hertz
+        /// </summary>
         private readonly Timer _tickTimer;
+        private EventWaitHandle _timerEvent;
+
 
         /// <summary>
         ///     Flag that controls whether the main loop will perform a nightly cleanup
@@ -194,8 +199,6 @@ namespace MBBSEmu.HostProcess
         {
             _workerThread.Join();
         }
-
-        private EventWaitHandle _timerEvent;
 
         private void WaitForNextTick()
         {

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -196,15 +196,21 @@ namespace MBBSEmu.HostProcess
 
         private EventWaitHandle _timerEvent;
 
-        private bool WaitForNextTick()
+        private void WaitForNextTick()
         {
             if (_channelDictionary.Values.Where(session => session.Status == 3 || session.DataFromClient.Count > 0 || session.DataToClient.Count > 0 || session.DataToProcess).Any())
-                return true;
+                return;
             //WaitHandle.WaitAny()
-            return _timerEvent.WaitOne();
+            Logger.Debug("Sleeping");
+            _timerEvent.WaitOne();
+            Logger.Debug("Awakened");
         }
 
-        public void TriggerProcessing() => _timerEvent.Set();
+        public void TriggerProcessing()
+        {
+            Logger.Debug("Setting timer event to signaled");
+            _timerEvent.Set();
+        }
 
         /// <summary>
         ///     This is the main MajorBBS/Worldgroup loop similar to how it actually functions with the software itself.
@@ -214,8 +220,10 @@ namespace MBBSEmu.HostProcess
         /// </summary>
         private void WorkerThread()
         {
-            while (_isRunning && WaitForNextTick())
+            while (_isRunning)
             {
+                WaitForNextTick();
+
                 ProcessNightlyCleanup();
 
                 //Handle Channels

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -179,6 +179,8 @@ namespace MBBSEmu.HostProcess
             _isRunning = false;
             _timer.Dispose();
             _tickTimer?.Dispose();
+            // this set must come after _isRunning is set to false, to trigger the exit of the
+            // worker thread.
             _timerEvent?.Set();
         }
 
@@ -198,7 +200,7 @@ namespace MBBSEmu.HostProcess
         private void WaitForNextTick()
         {
             if (_timerEvent == null ||
-                _channelDictionary.Values.Where(session => session.Status == 3 || session.DataFromClient.Count > 0 || session.DataToClient.Count > 0 || session.DataToProcess).Any())
+                _channelDictionary.Values.Where(session => session.DataFromClient.Count > 0 || session.DataToClient.Count > 0 || session.DataToProcess).Any())
                 return;
 
             _timerEvent.WaitOne();

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -134,12 +134,12 @@ namespace MBBSEmu.HostProcess
             _realTimeStopwatch = Stopwatch.StartNew();
             _incomingSessions = new Queue<SessionBase>();
             _cleanupTime = _configuration.CleanupTime;
-            _timer = new Timer(unused => _performCleanup = true, this, NowUntil(_cleanupTime), TimeSpan.FromDays(1));
+            _timer = new Timer(_ => _performCleanup = true, this, NowUntil(_cleanupTime), TimeSpan.FromDays(1));
 
             if (_configuration.TimerHertz > 0)
             {
                 _timerEvent = new AutoResetEvent(true);
-                _tickTimer = new Timer(unused => _timerEvent.Set(), this, TimeSpan.Zero, TimeSpan.FromMilliseconds(1000 / configuration.TimerHertz));
+                _tickTimer = new Timer(_ => _timerEvent.Set(), this, TimeSpan.Zero, TimeSpan.FromMilliseconds(1000 / configuration.TimerHertz));
             }
 
             Logger.Info("Constructed MBBSEmu Host!");
@@ -203,7 +203,7 @@ namespace MBBSEmu.HostProcess
         private void WaitForNextTick()
         {
             if (_timerEvent == null ||
-                _channelDictionary.Values.Where(session => session.DataFromClient.Count > 0 || session.DataToClient.Count > 0 || session.DataToProcess).Any())
+                _channelDictionary.Values.Any(session => session.DataFromClient.Count > 0 || session.DataToClient.Count > 0 || session.DataToProcess))
                 return;
 
             _timerEvent.WaitOne();

--- a/MBBSEmu/Server/Socket/SocketServer.cs
+++ b/MBBSEmu/Server/Socket/SocketServer.cs
@@ -73,7 +73,7 @@ namespace MBBSEmu.Server.Socket
                 case EnumSessionType.Telnet:
                     {
                         _logger.Info($"Accepting incoming Telnet connection from {client.RemoteEndPoint}...");
-                        var session = new TelnetSession(_logger, client, _configuration);
+                        var session = new TelnetSession(_host, _logger, client, _configuration);
                         _host.AddSession(session);
                         session.Start();
                         break;

--- a/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
+++ b/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
@@ -48,7 +48,7 @@ namespace MBBSEmu.Session.LocalConsole
                 0x00F0, 0x00F1, 0x00F2, 0x00F3, 0x00F4, 0x00F5, 0x00F6, 0x00F7, 0x00F8, 0x00F9, 0x00FA, 0x00FB, 0x00FC, 0x00FD, 0x00FE, 0x00FF  //F0
         };
 
-        public LocalConsoleSession(ILogger logger, string sessionId, IMbbsHost host) : base(sessionId)
+        public LocalConsoleSession(ILogger logger, string sessionId, IMbbsHost host) : base(host, sessionId, EnumSessionState.Unauthenticated)
         {
             _logger = logger;
             _host = host;
@@ -68,8 +68,6 @@ namespace MBBSEmu.Session.LocalConsole
             //Detect if we're on Windows and enable VT100 on the current Terminal Window
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 new Win32VT100().Enable();
-
-            SessionState = EnumSessionState.Unauthenticated;
 
             (_logger as CustomLogger)?.DisableConsoleLogging();
 

--- a/MBBSEmu/Session/Rlogin/RloginSession.cs
+++ b/MBBSEmu/Session/Rlogin/RloginSession.cs
@@ -17,7 +17,6 @@ namespace MBBSEmu.Session.Rlogin
     /// </summary>
     public class RloginSession : SocketSession
     {
-        private readonly IMbbsHost _host;
         private readonly PointerDictionary<SessionBase> _channelDictionary;
         private readonly AppSettings _configuration;
         private readonly List<string> rloginStrings = new List<string>();
@@ -25,9 +24,8 @@ namespace MBBSEmu.Session.Rlogin
 
         public readonly string ModuleIdentifier;
 
-        public RloginSession(IMbbsHost host, ILogger logger, Socket rloginConnection, PointerDictionary<SessionBase> channelDictionary, AppSettings configuration, string moduleIdentifier = null) : base(logger, rloginConnection)
+        public RloginSession(IMbbsHost host, ILogger logger, Socket rloginConnection, PointerDictionary<SessionBase> channelDictionary, AppSettings configuration, string moduleIdentifier = null) : base(host, logger, rloginConnection)
         {
-            _host = host;
             ModuleIdentifier = moduleIdentifier;
             _channelDictionary = channelDictionary;
             _configuration = configuration;
@@ -86,7 +84,7 @@ namespace MBBSEmu.Session.Rlogin
                 SessionState = EnumSessionState.LoggedOff;
                 return false;
             }
-            
+
             // we have 3 strings, pick out username and launch appropriately
             Username = rloginStrings.First(s => !string.IsNullOrEmpty(s));
 
@@ -96,7 +94,7 @@ namespace MBBSEmu.Session.Rlogin
 
             if (!string.IsNullOrEmpty(ModuleIdentifier))
             {
-                CurrentModule = _host.GetModule(ModuleIdentifier);
+                CurrentModule = _mbbsHost.GetModule(ModuleIdentifier);
                 InputBuffer.WriteByte((byte)CurrentModule.MenuOptionKey[0]);
                 SessionState = EnumSessionState.RloginEnteringModule;
             }

--- a/MBBSEmu/Session/SessionBase.cs
+++ b/MBBSEmu/Session/SessionBase.cs
@@ -244,7 +244,7 @@ namespace MBBSEmu.Session
             InputCommand = new byte[] { 0x0 };
 
             _enumSessionState = startingSessionState;
-            OnSessionStateChanged += (a, b) => mbbsHost.TriggerProcessing();
+            OnSessionStateChanged += (_, _) => mbbsHost.TriggerProcessing();
         }
 
         public void ProcessDataFromClient()

--- a/MBBSEmu/Session/SocketSession.cs
+++ b/MBBSEmu/Session/SocketSession.cs
@@ -127,7 +127,6 @@ namespace MBBSEmu.Session
             int bytesReceived;
             SocketError socketError;
 
-            // TODO rework trigger processing call
             try {
                 bytesReceived = _socket.EndReceive(asyncResult, out socketError);
                 if (bytesReceived == 0) {
@@ -137,7 +136,6 @@ namespace MBBSEmu.Session
                 }
             } catch (ObjectDisposedException) {
                 SessionState = EnumSessionState.LoggedOff;
-                _mbbsHost.TriggerProcessing();
                 return;
             }
 

--- a/MBBSEmu/Session/SocketSession.cs
+++ b/MBBSEmu/Session/SocketSession.cs
@@ -10,15 +10,13 @@ namespace MBBSEmu.Session
     public abstract class SocketSession : SessionBase
     {
         protected readonly ILogger _logger;
-        protected readonly IMbbsHost _mbbsHost;
         protected readonly Socket _socket;
         protected readonly Thread _senderThread;
         protected readonly byte[] _socketReceiveBuffer = new byte[9000];
         protected readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
 
-        protected SocketSession(IMbbsHost mbbsHost, ILogger logger, Socket socket) : base(socket.RemoteEndPoint.ToString())
+        protected SocketSession(IMbbsHost mbbsHost, ILogger logger, Socket socket) : base(mbbsHost, socket.RemoteEndPoint.ToString(), EnumSessionState.Negotiating)
         {
-            _mbbsHost = mbbsHost;
             _logger = logger;
 
             _socket = socket;

--- a/MBBSEmu/Session/Telnet/TelnetSession.cs
+++ b/MBBSEmu/Session/Telnet/TelnetSession.cs
@@ -1,3 +1,4 @@
+using MBBSEmu.HostProcess;
 using MBBSEmu.Session.Enums;
 using NLog;
 using System;
@@ -42,7 +43,7 @@ namespace MBBSEmu.Session.Telnet
 
         private readonly IacFilter _iacFilter;
 
-        public TelnetSession(ILogger logger, Socket telnetConnection, AppSettings configuration) : base(logger, telnetConnection)
+        public TelnetSession(IMbbsHost mbbsHost, ILogger logger, Socket telnetConnection, AppSettings configuration) : base(mbbsHost, logger, telnetConnection)
         {
             SessionType = EnumSessionType.Telnet;
             SessionState = EnumSessionState.Unauthenticated;

--- a/MBBSEmu/Session/TestSession.cs
+++ b/MBBSEmu/Session/TestSession.cs
@@ -11,7 +11,7 @@ namespace MBBSEmu.Session
     {
         private readonly BlockingCollection<byte> _data = new BlockingCollection<byte>();
 
-        public TestSession(IMbbsHost host) : base("test")
+        public TestSession(IMbbsHost host) : base(host, "test", EnumSessionState.EnteringModule)
         {
             SendToClientMethod = Send;
             OutputEnabled = true;
@@ -19,22 +19,9 @@ namespace MBBSEmu.Session
             CurrentModule = host?.GetModule("MBBSEMU");
 
             SessionType = EnumSessionType.Test;
-            SessionState = EnumSessionState.EnteringModule;
 
             Username = "Sysop";
             Email  = "sysop@grnet.com";
-        }
-
-        private EnumSessionState _enumSessionState;
-
-        public event EventHandler<EnumSessionState> OnSessionStateChanged;
-
-        public override EnumSessionState SessionState {
-            get => _enumSessionState;
-            set {
-                _enumSessionState = value;
-                OnSessionStateChanged?.Invoke(this, value);
-            }
         }
 
         public override void Stop() {}


### PR DESCRIPTION
Adds a wait to the main loop. The wait runs at a configurable hertz, controlled in `Timer.Hertz`

Value of 0 is full speed, or mbbsemu as it is today. Value of 1 is once a second, 2 is twice a second, etc. 

The code is smart enough to abort the waiting when user input is received. The socket threads will start the main loop and process accordingly, so it'll seem like a real time interaction without delay/jitter. 

Given that rti handlers run at 18 hz, most users should probably set this to 18 at a minimum, but lower values can work depending on which modules are loaded.