### PR TITLE
Fixes for Archery

### DIFF
--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -613,6 +613,9 @@ namespace MBBSEmu.HostProcess
             result &= 0xFF;
 
             session.LastCharacterReceived = (byte)result;
+
+            if (session.LastCharacterReceived == 0xD)
+                session.Status = 3;
         }
 
         /// <summary>
@@ -793,7 +796,7 @@ namespace MBBSEmu.HostProcess
                     }
 
                 //Enter or Return
-                case 0xD when session.SessionState != EnumSessionState.InFullScreenDisplay:
+                case 0xD when !session.TransparentMode && session.SessionState != EnumSessionState.InFullScreenDisplay:
                     {
                         if(!session.TransparentMode)
                             session.SendToClient(new byte[] { 0xD, 0xA });


### PR DESCRIPTION
- Do not process `0xD` if we're in Transparent Mode as the user hitting Enter (triggering STTROU)
- If BTUCHI returns `0xD`, trigger a `Status == 3` as if the User hit Enter (makes LORD work again after patching the above)

These were omitted from the refactor.... for reasons I don't know why. I'll claim I was drunk on Christmas Cheer 😛 

![image](https://user-images.githubusercontent.com/1139047/103389996-1a577100-4ae0-11eb-8057-6f0a44119d22.png)

![image](https://user-images.githubusercontent.com/1139047/103390016-2a6f5080-4ae0-11eb-8de6-705a77c981ab.png)
