### PR TITLE
Change RecordCount in the btrieve file to be 32-bits

### DIFF
--- a/MBBSEmu/Btrieve/BtrieveFile.cs
+++ b/MBBSEmu/Btrieve/BtrieveFile.cs
@@ -24,23 +24,23 @@ namespace MBBSEmu.Btrieve
         /// </summary>
         public ushort PageCount => (ushort) (Data.Length / PageLength - 1);
 
-        private ushort _recordCount;
+        private uint _recordCount;
         /// <summary>
         ///     Total Number of Records in the specified Btrieve File
         /// </summary>
-        public ushort RecordCount
+        public uint RecordCount
         {
             get
             {
                 if (Data?.Length > 0)
-                    return BitConverter.ToUInt16(Data, 0x1C);
+                    return BitConverter.ToUInt32(Data, 0x1A);
 
                 return _recordCount;
             }
             set
             {
                 if (Data?.Length > 0)
-                    Array.Copy(BitConverter.GetBytes(value), 0, Data, 0x1C, sizeof(ushort));
+                    Array.Copy(BitConverter.GetBytes(value), 0, Data, 0x1A, sizeof(uint));
 
                 _recordCount = value;
             }


### PR DESCRIPTION
Fixes the truncated Farwest Trivia databases which have 75k records