### PR TITLE
Added Ordinal uhskey() + tests and refactored gen_haskey() & othkey() + added tests

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
@@ -1,9 +1,9 @@
-﻿using MBBSEmu.Memory;
+﻿using MBBSEmu.Database.Repositories.Account;
+using MBBSEmu.Database.Repositories.AccountKey;
+using MBBSEmu.Memory;
+using MBBSEmu.Module;
 using System.Collections.Generic;
 using System.Text;
-using MBBSEmu.Database.Repositories.Account;
-using MBBSEmu.Database.Repositories.AccountKey;
-using MBBSEmu.Module;
 using Xunit;
 
 namespace MBBSEmu.Tests.ExportedModules.Majorbbs
@@ -13,6 +13,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
         private const ushort HASKEY_ORDINAL = 334;
         private const ushort HASMKEY_ORDINAL = 335;
+        private const ushort GEN_HASKEY_ORDINAL = 314;
+        private const ushort OTHKEY_ORDINAL = 457;
         private const ushort UIDKEY_ORDINAL = 609;
 
         [Fact]
@@ -31,6 +33,51 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASKEY_ORDINAL, new List<FarPtr> { stringPointer });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void gen_haskey_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            testSessions[0].Username = "sysop";
+            var key = "SYSOP";
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, GEN_HASKEY_ORDINAL, new List<ushort> { stringPointer.Offset, stringPointer.Segment, testSessions[0].Channel });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void othkey_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            testSessions[0].Username = "sysop";
+            var key = "SYSOP";
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+
+            mbbsEmuMemoryCore.GetVariablePointer("OTHUSN");
+            mbbsEmuMemoryCore.SetWord("OTHUSN", 0);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OTHKEY_ORDINAL, new List<FarPtr> { stringPointer });
 
             Assert.Equal(1, mbbsEmuCpuRegisters.AX);
 
@@ -95,6 +142,51 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
 
             //Execute Test
             ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, HASKEY_ORDINAL, new List<FarPtr> { stringPointer });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void gen_haskey_Empty_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            testSessions[0].Username = "sysop";
+            var key = "";
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, GEN_HASKEY_ORDINAL, new List<ushort> { stringPointer.Offset, stringPointer.Segment, testSessions[0].Channel });
+
+            Assert.Equal(1, mbbsEmuCpuRegisters.AX);
+
+        }
+
+        [Fact]
+        public void othkey_Empty_Test()
+        {
+            //Reset State
+            Reset();
+
+            //Set the test Username
+            testSessions[0].Username = "sysop";
+            var key = "";
+
+            //Set Argument Values to be Passed In
+            var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
+            mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
+
+            mbbsEmuMemoryCore.GetVariablePointer("OTHUSN");
+            mbbsEmuMemoryCore.SetWord("OTHUSN", 0);
+
+            //Execute Test
+            ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, OTHKEY_ORDINAL, new List<FarPtr> { stringPointer });
 
             Assert.Equal(1, mbbsEmuCpuRegisters.AX);
 

--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/key_Tests.cs
@@ -73,7 +73,6 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
             mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
 
-            mbbsEmuMemoryCore.GetVariablePointer("OTHUSN");
             mbbsEmuMemoryCore.SetWord("OTHUSN", 0);
 
             //Execute Test
@@ -182,7 +181,6 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
             var stringPointer = mbbsEmuMemoryCore.AllocateVariable("INPUT_STRING", (ushort)(key.Length + 1));
             mbbsEmuMemoryCore.SetArray("INPUT_STRING", Encoding.ASCII.GetBytes("SYSOP"));
 
-            mbbsEmuMemoryCore.GetVariablePointer("OTHUSN");
             mbbsEmuMemoryCore.SetWord("OTHUSN", 0);
 
             //Execute Test

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -4212,7 +4212,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
             Module.Memory.SetArray(Module.Memory.GetVariablePointer("OTHEXP"), userExtAcc.Data);
 
 #if DEBUG
-            _logger.Debug($"User Found -- Channel {userSession.Channel}, user[] offset {userBase}");
+            _logger.Debug($"({Module.ModuleIdentifier}) User Found -- Channel {userSession.Channel}, user[] offset {userBase}");
 #endif
             Registers.AX = 1;
         }
@@ -7138,7 +7138,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 ? (ushort)1
                 : (ushort)0;
 #if DEBUG
-            _logger.Debug($"Returning {Registers.AX} for Haskey({accountLock})");
+            _logger.Debug($"({Module.ModuleIdentifier}) Returning {Registers.AX} for othkey({accountLock})");
 #endif
         }
 
@@ -7313,7 +7313,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 ? (ushort)1
                 : (ushort)0;
 #if DEBUG
-            _logger.Debug($"Returning {Registers.AX} for Haskey({accountLock})");
+            _logger.Debug($"({Module.ModuleIdentifier}) Returning {Registers.AX} for gen_haskey({accountLock})");
 #endif
         }
 

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -1163,6 +1163,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
                 case 51:
                     aabbtv();
                     break;
+                case 746: // uhskey() same signature and purpose, uidkey() is for offline users
                 case 609:
                     uidkey();
                     break;


### PR DESCRIPTION
-Added ordinal 746 uhskey(), same signature and purpose as uidkey(), added to switch
-refactored ordinal 314 gen_haskey() + added tests, tested with NTHORDER issue #73 is where it was added
-refactored ordinal 457 othkey() + added tests, added before github so cannot test with module
