### PR TITLE
Update FsdRoutines.cs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,7 +8,13 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
-
+  # This enables the manual "Run workflow" button
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual run'
+        required: false
+        default: 'Manual Build'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
+++ b/MBBSEmu/HostProcess/HostRoutines/FsdRoutines.cs
@@ -469,10 +469,13 @@ namespace MBBSEmu.HostProcess.HostRoutines
                         {
                             if (_fsdFields[session.Channel].SelectedOrdinal == 0)
                             {
-                                //Cycle back to the bottom
-                                _fsdFields[session.Channel].SelectedOrdinal =
-                                    _fsdFields[session.Channel].Fields
-                                        .Count(f => f.FsdFieldType != EnumFsdFieldType.Error) - 1;
+                                // Cycle back to the bottom — find the last non-readonly, non-error field
+                                var lastValid = _fsdFields[session.Channel].Fields.Count - 1;
+                                while (lastValid > 0 && 
+                                        (_fsdFields[session.Channel].Fields[lastValid].FsdFieldType == EnumFsdFieldType.Error ||
+                                        _fsdFields[session.Channel].Fields[lastValid].IsReadOnly))
+                                    lastValid--;
+                                _fsdFields[session.Channel].SelectedOrdinal = lastValid;
                                 break;
                             }
 


### PR DESCRIPTION
More robust handling to address https://github.com/mbbsemu/MBBSEmu/issues/554
Testing by multiple users over 24 hours has thus far shown this to resolve the issue.

Per Claude:
```
Fix FSD/FSE crash when cycling past the first field with up arrow

The CRSUP wrap-around was using Count(f => f.FsdFieldType != Error) - 1
to set SelectedOrdinal, which excludes Error-type fields from the count
but uses the result as a direct index into the full Fields list. This
could set SelectedOrdinal to a value that lands on an Error field or
out of bounds entirely, causing an ArgumentOutOfRangeException.

Fixed by scanning backwards from the end of the Fields list to find the
actual index of the last non-readonly, non-error field instead of
computing a filtered count.

Resolves #554
```