### PR TITLE
Memory Leaks fixes

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -106,7 +106,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             foreach (var f in FilePointerDictionary)
             {
-                f.Value.Close();
+                f.Value.Dispose();
                 _logger.Warn($"({Module.ModuleIdentifier}) WARNING -- File: {f.Value.Name} left open by module, closing");
             }
             FilePointerDictionary.Clear();

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -122,6 +122,10 @@ namespace MBBSEmu.HostProcess.ExportedModules
         {
             _tfsStreamReader?.Dispose();
 
+            foreach (var search in _activeSearches.Values)
+                search.Dispose();
+            _activeSearches.Clear();
+
             base.Dispose();
         }
 

--- a/MBBSEmu/Server/Socket/SocketServer.cs
+++ b/MBBSEmu/Server/Socket/SocketServer.cs
@@ -54,7 +54,7 @@ namespace MBBSEmu.Server.Socket
 
         public void Stop()
         {
-            _listenerSocket.Close();
+            _listenerSocket.Dispose();
         }
 
         private void OnNewConnection(IAsyncResult asyncResult) {

--- a/MBBSEmu/Session/SocketSession.cs
+++ b/MBBSEmu/Session/SocketSession.cs
@@ -213,6 +213,7 @@ namespace MBBSEmu.Session
 
             // send signal to the send thread to abort
             _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
         }
     }
 }


### PR DESCRIPTION
I was able to fix resource leaks in session teardown and module cleanup. This should prevent the memory issues I experienced.

- Dispose CancellationTokenSource in SocketSession.CloseSocket() after Cancel() to release unmanaged resources on every session disconnect
- Dispose active file search enumerators (fnd1st/fndnxt) in Majorbbs.Dispose() to prevent file handle leaks when searches are abandoned before completion
- Use Dispose() instead of Close() on FileStream and Socket for idiomatic IDisposable cleanup