### PR TITLE
Make socket session close idempotent

### DIFF
--- a/MBBSEmu/Session/SocketSession.cs
+++ b/MBBSEmu/Session/SocketSession.cs
@@ -15,6 +15,7 @@ namespace MBBSEmu.Session
         protected readonly Thread _senderThread;
         protected readonly byte[] _socketReceiveBuffer = new byte[9000];
         protected readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+        private int _socketClosed;
 
         protected SocketSession(IMbbsHost mbbsHost, IMessageLogger logger, Socket socket, ITextVariableService textVariableService) : base(mbbsHost, socket.RemoteEndPoint.ToString(), EnumSessionState.Negotiating, textVariableService)
         {
@@ -204,16 +205,21 @@ namespace MBBSEmu.Session
         }
 
         protected void CloseSocket(string reason) {
+            if (Interlocked.Exchange(ref _socketClosed, 1) != 0) {
+                return;
+            }
+
             if (SessionState != EnumSessionState.LoggedOff) {
                 _logger.Warn($"Session {SessionId} (Channel: {Channel}) {reason}");
             }
 
-            _socket.Close();
             SessionState = EnumSessionState.LoggedOff;
 
             // send signal to the send thread to abort
             _cancellationTokenSource.Cancel();
             _cancellationTokenSource.Dispose();
+
+            _socket.Close();
         }
     }
 }


### PR DESCRIPTION
 ## Summary

  Fixes a crash when a socket session is closed more than once during disconnect handling.

  `SocketSession.CloseSocket()` could be reached from multiple paths for the same client disconnect. The first call
  closed the session and disposed the cancellation token source, but a later forced stop could call `CloseSocket()`
  again and attempt to cancel an already-disposed token source, causing an `ObjectDisposedException`.

  This change makes socket close handling idempotent so repeated close requests for the same session are safely ignored
  after the first one.

  ## Details

  - Adds an atomic guard to `SocketSession.CloseSocket()`.
  - Prevents duplicate close/cleanup work for the same socket session.
  - Avoids calling `Cancel()` or `Dispose()` on an already-disposed cancellation token source.
  - Keeps the original close behavior intact for the first close request.

Validated with a published single-file Linux x64 build in a live MBBSEmu configuration; the disconnect crash no
  longer reproduces.