### PR TITLE
Keep RTKICK running after console cleanup

### DIFF
--- a/MBBSEmu/HostProcess/ExportedModules/Doscalls.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Doscalls.cs
@@ -22,7 +22,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         public const ushort DosSegmentBase = 0x200;
         public ushort DosSegmentOffset = 0;
 
-        public new void Dispose()
+        public override void Dispose()
         {
             base.Dispose();
         }

--- a/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/ExportedModuleBase.cs
@@ -102,7 +102,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private protected const ushort ACCBB_BASE_SEGMENT = 0x3001;
         private protected const ushort MaxTextVariables = 64;
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             foreach (var f in FilePointerDictionary)
             {

--- a/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galgsbl.cs
@@ -36,8 +36,9 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private const ushort ERROR_CHANNEL_NOT_DEFINED = 0xFFF6;
         private const ushort ERROR_CHANNEL_OUT_OF_RANGE = 0xFFF5;
 
-        public new void Dispose()
+        public override void Dispose()
         {
+            _timer?.Dispose();
             base.Dispose();
         }
 

--- a/MBBSEmu/HostProcess/ExportedModules/Galme.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galme.cs
@@ -18,7 +18,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         public const ushort Segment = 0xFFFC;
 
-        public new void Dispose()
+        public override void Dispose()
         {
             base.Dispose();
         }

--- a/MBBSEmu/HostProcess/ExportedModules/Galmsg.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Galmsg.cs
@@ -15,7 +15,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
         public const ushort Segment = 0xFFFA;
 
-        public new void Dispose()
+        public override void Dispose()
         {
             base.Dispose();
         }

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -118,7 +118,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private StreamReader _tfsStreamReader;
         //  -------------------------------------
 
-        public new void Dispose()
+        public override void Dispose()
         {
             _tfsStreamReader?.Dispose();
 

--- a/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Phapi.cs
@@ -23,7 +23,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
         /// <returns></returns>
         public const ushort Segment = 0xFFFD;
 
-        public new void Dispose()
+        public override void Dispose()
         {
             base.Dispose();
         }

--- a/MBBSEmu/HostProcess/MbbsHost.cs
+++ b/MBBSEmu/HostProcess/MbbsHost.cs
@@ -16,6 +16,7 @@ using MBBSEmu.Reports;
 using MBBSEmu.Session;
 using MBBSEmu.Session.Attributes;
 using MBBSEmu.Session.Enums;
+using MBBSEmu.Session.LocalConsole;
 using MBBSEmu.Session.Rlogin;
 using MBBSEmu.TextVariables;
 using MBBSEmu.Util;
@@ -1454,7 +1455,10 @@ namespace MBBSEmu.HostProcess
             foreach (var c in _channelDictionary)
                 _channelDictionary[c.Value.Channel].SendToClient($"|RESET|\r\n|B||RED|Nightly Cleanup Running -- Please log back on shortly|RESET|\r\n".EncodeToANSIArray());
 
-            // removes all sessions and stops worker thread
+            foreach (var localConsoleSession in _channelDictionary.Values.OfType<LocalConsoleSession>())
+                localConsoleSession.StopHostOnStop = false;
+
+            // removes all sessions before module cleanup
             RemoveSessions(session => true);
 
             CallModuleRoutine("mcurou", module => Logger.Info($"Calling nightly cleanup routine on module {module.ModuleIdentifier}"));

--- a/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
+++ b/MBBSEmu/Session/LocalConsole/LocalConsoleSession.cs
@@ -23,6 +23,7 @@ namespace MBBSEmu.Session.LocalConsole
         private readonly Thread _consoleOutputThread;
         private bool _consoleInputThreadIsRunning;
         private readonly bool _processClientData;
+        public bool StopHostOnStop { get; set; } = true;
 
         /// <summary>
         ///     This array allows for easy conversion between Extended ASCII codes used by MajorBBS/WG modules for ANSI graphics and their Unicode
@@ -134,7 +135,8 @@ namespace MBBSEmu.Session.LocalConsole
 
             _consoleInputThreadIsRunning = false;
             _timer.Dispose();
-            _host?.Stop();
+            if (StopHostOnStop)
+                _host?.Stop();
 
             Console.Clear();
             // the thread is stuck in ReadKey, the user needs to free that thread to end the


### PR DESCRIPTION
## Summary

  - Prevent local console session teardown during nightly cleanup from stopping the host timer.
  - Allow exported module `Dispose()` overrides to run during cleanup.
  - Dispose the GALGSBL timer when exported modules are torn down.

  ## Root Cause

  When nightly cleanup removed all sessions, `LocalConsoleSession.Stop()` stopped the host. That disposed the host tick
  timer before the module was reloaded, so RTKICK registrations after cleanup were accepted but never executed.

  Several exported modules also hid `Dispose()` with `new` instead of overriding it, so cleanup through the base/
  interface path could skip derived cleanup such as the GALGSBL timer.