### PR TITLE
Fix Btrieve cursor after absolute position lookup

### DIFF
--- a/MBBSEmu.Tests/ExportedModules/Majorbbs/anpbtv_Tests.cs
+++ b/MBBSEmu.Tests/ExportedModules/Majorbbs/anpbtv_Tests.cs
@@ -13,6 +13,8 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
         private const ushort RECORD_LENGTH = 80;
         private const int ABSBTV = 53;
         private const int QRYBTV = 485;
+        private const int QNPBTV = 484;
+        private const int GABBTV = 999;
         private const int ANPBTV = 70;
         private const int ANPBTVL = 913;
 
@@ -143,6 +145,34 @@ namespace MBBSEmu.Tests.ExportedModules.Majorbbs
           ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, ABSBTV, new List<ushort> {});
           mbbsEmuCpuRegisters.GetLong().Should().Be(5);
         }
+
+        [Fact]
+        public void qnpbtv_after_gabbtv_continues_from_absolute_position()
+        {
+          Reset();
+
+          AllocateBB(CreateBtrieveFile(), RECORD_LENGTH);
+
+          var keyPtr = mbbsEmuMemoryCore.AllocateVariable(null, 128);
+          mbbsEmuMemoryCore.SetArray(keyPtr, Encoding.ASCII.GetBytes("ABC"));
+
+          ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, QRYBTV, new List<ushort> { keyPtr.Offset, keyPtr.Segment, /* key= */ 0, (ushort)EnumBtrieveOperationCodes.QueryGreaterOrEqual });
+          mbbsEmuCpuRegisters.AX.Should().NotBe(0);
+
+          ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, ABSBTV, new List<ushort> {});
+          mbbsEmuCpuRegisters.GetLong().Should().Be(1);
+
+          var record = mbbsEmuMemoryCore.AllocateVariable(null, RECORD_LENGTH);
+          ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, GABBTV, new List<ushort> { record.Offset, record.Segment, /* abspos= */ 5, 0, /* key= */ 0 });
+          mbbsEmuMemoryCore.GetByte(record + RECORD_LENGTH - 1).Should().Be(5);
+
+          ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, QNPBTV, new List<ushort> { (ushort)EnumBtrieveOperationCodes.QueryNext});
+          mbbsEmuCpuRegisters.AX.Should().NotBe(0);
+
+          ExecuteApiTest(HostProcess.ExportedModules.Majorbbs.Segment, ABSBTV, new List<ushort> {});
+          mbbsEmuCpuRegisters.GetLong().Should().Be(6);
+        }
+
         private BtrieveFile CreateBtrieveFile()
         {
           var btrieveFile = new BtrieveFile()

--- a/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
+++ b/MBBSEmu/HostProcess/ExportedModules/Majorbbs.cs
@@ -2619,9 +2619,11 @@ namespace MBBSEmu.HostProcess.ExportedModules
         private bool UpdateBB(BtrieveFileProcessor currentBtrieveFile, FarPtr destinationRecordBuffer, EnumBtrieveOperationCodes operationCode, short keyNumber = -1) =>
             UpdateBB(currentBtrieveFile, destinationRecordBuffer, currentBtrieveFile.Position, operationCode.AcquiresData(), keyNumber);
 
-        private bool UpdateBB(BtrieveFileProcessor currentBtrieveFile, FarPtr destinationRecordBuffer, uint position, bool acquiresData, short keyNumber = -1)
+        private bool UpdateBB(BtrieveFileProcessor currentBtrieveFile, FarPtr destinationRecordBuffer, uint position, bool acquiresData, short keyNumber = -1, bool setLogicalPosition = false)
         {
-            var record = currentBtrieveFile.GetRecord(position);
+            var record = setLogicalPosition && keyNumber >= 0
+                ? currentBtrieveFile.GetRecord(position, keyNumber)
+                : currentBtrieveFile.GetRecord(position);
             if (record == null)
                 return false;
 
@@ -5171,7 +5173,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var currentBtrieveFile = BtrieveGetProcessor(Module.Memory.GetPointer("BB"));
 
-            UpdateBB(currentBtrieveFile, recordPointer, (uint)absolutePosition, acquiresData: true, (short)keynum);
+            UpdateBB(currentBtrieveFile, recordPointer, (uint)absolutePosition, acquiresData: true, (short)keynum, setLogicalPosition: true);
         }
 
         /// <summary>
@@ -7413,7 +7415,7 @@ namespace MBBSEmu.HostProcess.ExportedModules
 
             var currentBtrieveFile = BtrieveGetProcessor(Module.Memory.GetPointer("BB"));
 
-            Registers.AX = UpdateBB(currentBtrieveFile, recordPointer, (uint)absolutePosition, acquiresData: true, (short)keynum) ? (ushort)1 : (ushort)0;
+            Registers.AX = UpdateBB(currentBtrieveFile, recordPointer, (uint)absolutePosition, acquiresData: true, (short)keynum, setLogicalPosition: true) ? (ushort)1 : (ushort)0;
         }
 
         /// <summary>


### PR DESCRIPTION
Description

This fixes Btrieve absolute-position lookups so subsequent keyed navigation continues from the restored record.

gabbtv()/aabbtv() were loading the requested record by absolute position, but they were not restoring the logical Btrieve cursor for the supplied key number. Modules that call gabbtv(..., keynum) and then continue with qnxbtv() could resume from the wrong cursor state or terminate the keyed scan early.

This was observed in Galactic Empire’s planet update loop: after restoring a saved planet record position, qnxbtv() failed to continue through the remaining key-2 planet records, so later owned planets were skipped.

Changes

- Update absolute-position Btrieve record loads to optionally restore logical key position.
- Use that behavior for gabbtv() and aabbtv().
- Add a regression test verifying qnpbtv(QueryNext) continues from the record loaded by gabbtv().